### PR TITLE
Add bcs deserialization 

### DIFF
--- a/crates/framework/mos-stdlib/sources/bcd.move
+++ b/crates/framework/mos-stdlib/sources/bcd.move
@@ -1,0 +1,50 @@
+/// Source from https://github.com/aptos-labs/aptos-core/blob/main/aptos-move/framework/aptos-stdlib/sources/from_bcs.move
+
+/// This module provides a number of functions to convert _primitive_ types from their representation in `std::bcs`
+/// to values. This is the opposite of `bcs::to_bytes`. Note that it is not safe to define a generic public `from_bytes`
+/// function because this can violate implicit struct invariants, therefore only primitive types are offerred. If
+/// a general conversion back-and-force is needed, consider the `aptos_std::Any` type which preserves invariants.
+module mos_std::bcd{
+    use std::string::{Self, String};
+
+    /// UTF8 check failed in conversion from bytes to string
+    const EINVALID_UTF8: u64 = 0x1;
+
+    public fun to_bool(v: vector<u8>): bool {
+        from_bytes<bool>(v)
+    }
+
+    public fun to_u8(v: vector<u8>): u8 {
+        from_bytes<u8>(v)
+    }
+
+    public fun to_u64(v: vector<u8>): u64 {
+        from_bytes<u64>(v)
+    }
+
+    public fun to_u128(v: vector<u8>): u128 {
+        from_bytes<u128>(v)
+    }
+
+    public fun to_address(v: vector<u8>): address {
+        from_bytes<address>(v)
+    }
+
+    public fun to_string(v: vector<u8>): String {
+        // To make this safe, we need to evaluate the utf8 invariant.
+        let s = from_bytes<String>(v);
+        assert!(string::internal_check_utf8(string::bytes(&s)), EINVALID_UTF8);
+        s
+    }
+
+    /// Package private native function to deserialize a type T.
+    ///
+    /// Note that this function does not put any constraint on `T`. If code uses this function to
+    /// deserialize a linear value, its their responsibility that the data they deserialize is
+    /// owned.
+    public(friend) native fun from_bytes<MoveValue>(bytes: &vector<u8>): MoveValue;
+    
+    // TODO: declare friend modules here.
+
+    // TODO: add test cases for this module.
+}

--- a/crates/framework/mos-stdlib/sources/bcd.move
+++ b/crates/framework/mos-stdlib/sources/bcd.move
@@ -5,36 +5,24 @@
 /// function because this can violate implicit struct invariants, therefore only primitive types are offerred. If
 /// a general conversion back-and-force is needed, consider the `aptos_std::Any` type which preserves invariants.
 module mos_std::bcd{
-    use std::string::{Self, String};
-
-    /// UTF8 check failed in conversion from bytes to string
-    const EINVALID_UTF8: u64 = 0x1;
-
-    public fun to_bool(v: vector<u8>): bool {
+    public fun to_bool(v: &vector<u8>): bool {
         from_bytes<bool>(v)
     }
 
-    public fun to_u8(v: vector<u8>): u8 {
+    public fun to_u8(v: &vector<u8>): u8 {
         from_bytes<u8>(v)
     }
 
-    public fun to_u64(v: vector<u8>): u64 {
+    public fun to_u64(v: &vector<u8>): u64 {
         from_bytes<u64>(v)
     }
 
-    public fun to_u128(v: vector<u8>): u128 {
+    public fun to_u128(v: &vector<u8>): u128 {
         from_bytes<u128>(v)
     }
 
-    public fun to_address(v: vector<u8>): address {
+    public fun to_address(v: &vector<u8>): address {
         from_bytes<address>(v)
-    }
-
-    public fun to_string(v: vector<u8>): String {
-        // To make this safe, we need to evaluate the utf8 invariant.
-        let s = from_bytes<String>(v);
-        assert!(string::internal_check_utf8(string::bytes(&s)), EINVALID_UTF8);
-        s
     }
 
     /// Package private native function to deserialize a type T.

--- a/crates/framework/mos-stdlib/sources/table.move
+++ b/crates/framework/mos-stdlib/sources/table.move
@@ -6,7 +6,9 @@
 /// struct itself, while the operations are implemented as native functions. No traversal is provided.
 
 module mos_std::table {
-
+    
+    friend mos_std::type_table;
+    
     /// Type of tables
     struct Table<phantom K: copy + drop, phantom V> has store {
         handle: address,

--- a/crates/framework/mos-stdlib/sources/table.move
+++ b/crates/framework/mos-stdlib/sources/table.move
@@ -6,9 +6,7 @@
 /// struct itself, while the operations are implemented as native functions. No traversal is provided.
 
 module mos_std::table {
-    
-    friend mos_std::type_table;
-    
+
     /// Type of tables
     struct Table<phantom K: copy + drop, phantom V> has store {
         handle: address,

--- a/crates/framework/src/natives/mod.rs
+++ b/crates/framework/src/natives/mod.rs
@@ -16,6 +16,7 @@ pub struct GasParameters {
     type_info: mos_stdlib::type_info::GasParameters,
     rlp: mos_stdlib::rlp::GasParameters,
     account: mos_framework::account::GasParameters,
+    bcd: mos_stdlib::bcd::GasParameters,
 }
 
 impl GasParameters {
@@ -27,6 +28,7 @@ impl GasParameters {
             type_info: mos_stdlib::type_info::GasParameters::zeros(),
             rlp: mos_stdlib::rlp::GasParameters::zeros(),
             account: mos_framework::account::GasParameters::zeros(),
+            bcd: mos_stdlib::bcd::GasParameters::zeros(),
         }
     }
 }
@@ -34,11 +36,13 @@ impl GasParameters {
 pub fn all_natives(gas_params: GasParameters) -> NativeFunctionTable {
     let mut native_fun_table =
         move_stdlib::natives::all_natives(*MOVE_STD_ADDRESS, gas_params.move_stdlib);
-    
-    let nursery_fun_table = move_stdlib::natives::nursery_natives(*MOVE_STD_ADDRESS, gas_params.move_nursery);
+
+    let nursery_fun_table =
+        move_stdlib::natives::nursery_natives(*MOVE_STD_ADDRESS, gas_params.move_nursery);
     native_fun_table.extend(nursery_fun_table);
-    
-    let table_fun_table = move_table_extension::table_natives(*MOS_STD_ADDRESS, gas_params.table_extension);
+
+    let table_fun_table =
+        move_table_extension::table_natives(*MOS_STD_ADDRESS, gas_params.table_extension);
     native_fun_table.extend(table_fun_table);
 
     let mut natives = vec![];
@@ -52,8 +56,12 @@ pub fn all_natives(gas_params: GasParameters) -> NativeFunctionTable {
     }
 
     // mos_stdlib natives
-    add_natives!("type_info", mos_stdlib::type_info::make_all(gas_params.type_info));
+    add_natives!(
+        "type_info",
+        mos_stdlib::type_info::make_all(gas_params.type_info)
+    );
     add_natives!("rlp", mos_stdlib::rlp::make_all(gas_params.rlp));
+    add_natives!("bcd", mos_stdlib::bcd::make_all(gas_params.bcd));
 
     // mos_framework natives
     add_natives!(

--- a/crates/framework/src/natives/mos_stdlib/bcd.rs
+++ b/crates/framework/src/natives/mos_stdlib/bcd.rs
@@ -1,0 +1,88 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::vm_status::StatusCode;
+use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+};
+use smallvec::smallvec;
+use std::{collections::VecDeque, sync::Arc};
+
+use crate::natives::helpers::make_module_natives;
+
+#[derive(Debug, Clone)]
+pub struct FromBytesGasParameters {}
+
+impl FromBytesGasParameters {
+    pub fn zeros() -> Self {
+        Self {}
+    }
+}
+
+/// Rust implementation of Move's `native public(friend) fun from_bytes<T>(vector<u8>): T in bcs module`
+/// Bytes are in BCS (Binary Canonical Serialization) format.
+#[inline]
+fn native_from_bytes(
+    _gas_params: &FromBytesGasParameters,
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert_eq!(ty_args.len(), 1);
+    debug_assert_eq!(args.len(), 1);
+
+    let cost = 0.into();
+
+    // TODO(Gas): charge for getting the layout
+    let layout = context.type_to_type_layout(&ty_args[0])?.ok_or_else(|| {
+        PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(format!(
+            "Failed to get layout of type {:?} -- this should not happen",
+            ty_args[0]
+        ))
+    })?;
+
+    let bytes = pop_arg!(args, Vec<u8>);
+    let val = match Value::simple_deserialize(&bytes, &layout) {
+        Some(val) => val,
+        None => {
+            // TODO(gas): charge the gas for the failure.
+            return Err(PartialVMError::new(StatusCode::VALUE_DESERIALIZATION_ERROR));
+        }
+    };
+    // TODO(gas): charge gas for deserialization
+
+    Ok(NativeResult::ok(cost, smallvec![val]))
+}
+
+pub fn make_native_from_bytes(gas_params: FromBytesGasParameters) -> NativeFunction {
+    Arc::new(
+        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+            native_from_bytes(&gas_params, context, ty_args, args)
+        },
+    )
+}
+
+/***************************************************************************************************
+ * module
+ **************************************************************************************************/
+
+#[derive(Debug, Clone)]
+pub struct GasParameters {
+    pub from_bytes: FromBytesGasParameters,
+}
+
+impl GasParameters {
+    pub fn zeros() -> Self {
+        Self {
+            from_bytes: FromBytesGasParameters::zeros(),
+        }
+    }
+}
+
+pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
+    let natives = [("from_bytes", make_native_from_bytes(gas_params.from_bytes))];
+
+    make_module_natives(natives)
+}

--- a/crates/framework/src/natives/mos_stdlib/mod.rs
+++ b/crates/framework/src/natives/mos_stdlib/mod.rs
@@ -1,5 +1,6 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+pub mod bcd;
 pub mod rlp;
 pub mod type_info;


### PR DESCRIPTION
Add `from_bytes` native function and `bcd` module for bcs bytes deserialization. Resolve #22 .