### PR TITLE
[test_runner] Fix test runner and bcd argument bugs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,5 +24,6 @@ jobs:
     - name: Lint rust sources
       run: cargo clippy --all-targets --all-features --tests --benches -- -D warnings
     - name: Execute rust tests
-      run: cargo nextest run --workspace --all-features
-    
+      run: cargo nextest run --workspace --workspace --all-features
+    - name: Build
+      run: cargo build 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,6 +24,6 @@ jobs:
     - name: Lint rust sources
       run: cargo clippy --all-targets --all-features --tests --benches -- -D warnings
     - name: Execute rust tests
-      run: cargo nextest run --workspace --workspace --all-features
+      run: cargo nextest run --workspace --all-features
     - name: Build
       run: cargo build 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rust-version = "1.68"
 moveos = { path = "crates/moveos" }
 statedb = { path = "crates/statedb" }
 framework = { path = "crates/framework" }
-integration-test-runner = { path = "crates/integration-test-runner" }
+mos-integration-test-runner = { path = "crates/integration-test-runner" }
 
 # External crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.

--- a/crates/framework/Cargo.toml
+++ b/crates/framework/Cargo.toml
@@ -16,6 +16,7 @@ move-binary-format = { workspace = true }
 move-bytecode-utils = { workspace = true }
 move-bytecode-verifier = { workspace = true }
 move-core-types = { workspace = true }
+move-command-line-common = { workspace = true }
 move-stdlib = { workspace = true }
 move-table-extension = { workspace = true }
 move-unit-test = { workspace = true, optional = true }
@@ -24,3 +25,11 @@ move-vm-test-utils = { workspace = true }
 move-vm-types = { workspace = true }
 move-package = { workspace = true }
 move-prover = { workspace = true }
+
+[dev-dependencies]
+mos-integration-test-runner = { workspace = true }
+datatest-stable = { workspace = true }
+
+[[test]]
+harness = false
+name = "tests"

--- a/crates/framework/mos-framework/Move.toml
+++ b/crates/framework/mos-framework/Move.toml
@@ -6,6 +6,7 @@ version = "0.0.1"
 std = "0x1"
 mos_std = "0x1"
 mos_framework = "0x1"
+vm_reserved = "0x0"
 
 [dependencies]
 MosStdLib = { local = "../mos-stdlib" }

--- a/crates/framework/mos-framework/sources/account.move
+++ b/crates/framework/mos-framework/sources/account.move
@@ -31,13 +31,12 @@ module mos_framework::account{
    /// is returned. This way, the caller of this function can publish additional resources under
    /// `new_address`.
    public(friend) fun create_account(new_address: address): signer {
-      // there cannot be an Account resource under new_addr already.
-      assert!(!exists<Account>(new_address), error::already_exists(EAccountAlreadyExists));
-
       assert!(
          new_address != @vm_reserved && new_address != @mos_framework,
          error::invalid_argument(EAddressReseved)
       );
+      // there cannot be an Account resource under new_addr already.
+      assert!(!exists<Account>(new_address), error::already_exists(EAccountAlreadyExists));      
 
       create_account_unchecked(new_address)
    }

--- a/crates/framework/mos-framework/sources/account.move
+++ b/crates/framework/mos-framework/sources/account.move
@@ -1,8 +1,69 @@
 module mos_framework::account{
+   
+   use std::error;
+   use std::bcs;
+   use std::vector;
 
-   public fun create_account(_auth_key: vector<u8>): signer{
-      abort 0
+   /// Account already exists
+   const EAccountAlreadyExists: u64 = 1;
+   /// Account does not exist
+   const EAccountNoesNotExist: u64 = 2;
+   /// The provided authentication key has an invalid length
+   const EMalformedAuthenticationKey: u64 = 4;
+   /// Cannot create account because address is reserved
+   const EAddressReseved: u64 = 5;
+
+   /// Resource representing an account.
+   struct Account has key, store {
+      authentication_key: vector<u8>,
+      //TODO do we need a global account sequence number? every object has a sequence number
+      //sequence_number: u64,
+      //guid_creation_num: u64,
    }
+
+   /// TODO should provide a entry function at this module
+   /// How to provide account extension?
+   public entry fun create_account_entry(auth_key: address): signer{
+      Self::create_account(auth_key)
+   }
+
+   /// Publishes a new `Account` resource under `new_address`. A signer representing `new_address`
+   /// is returned. This way, the caller of this function can publish additional resources under
+   /// `new_address`.
+   public(friend) fun create_account(new_address: address): signer {
+      // there cannot be an Account resource under new_addr already.
+      assert!(!exists<Account>(new_address), error::already_exists(EAccountAlreadyExists));
+
+      assert!(
+         new_address != @vm_reserved && new_address != @mos_framework,
+         error::invalid_argument(EAddressReseved)
+      );
+
+      create_account_unchecked(new_address)
+   }
+
+   fun create_account_unchecked(new_address: address): signer {
+      let new_account = create_signer(new_address);
+      let authentication_key = bcs::to_bytes(&new_address);
+      assert!(
+         vector::length(&authentication_key) == 32,
+         error::invalid_argument(EMalformedAuthenticationKey)
+      );
+      move_to(
+         &new_account,
+         Account {
+               authentication_key,
+         }
+      );
+
+      new_account
+   }
+
+   #[view]
+   public fun exists_at(addr: address): bool {
+      exists<Account>(addr)
+   }
+
 
    native fun create_signer(addr: address): signer;
 }

--- a/crates/framework/mos-framework/sources/account.move
+++ b/crates/framework/mos-framework/sources/account.move
@@ -35,6 +35,7 @@ module mos_framework::account{
          new_address != @vm_reserved && new_address != @mos_framework,
          error::invalid_argument(EAddressReseved)
       );
+      
       // there cannot be an Account resource under new_addr already.
       assert!(!exists<Account>(new_address), error::already_exists(EAccountAlreadyExists));      
 

--- a/crates/framework/mos-framework/sources/account.move
+++ b/crates/framework/mos-framework/sources/account.move
@@ -7,7 +7,7 @@ module mos_framework::account{
    /// Account already exists
    const EAccountAlreadyExists: u64 = 1;
    /// Account does not exist
-   const EAccountNoesNotExist: u64 = 2;
+   const EAccountNotExist: u64 = 2;
    /// The provided authentication key has an invalid length
    const EMalformedAuthenticationKey: u64 = 4;
    /// Cannot create account because address is reserved
@@ -35,7 +35,7 @@ module mos_framework::account{
          new_address != @vm_reserved && new_address != @mos_framework,
          error::invalid_argument(EAddressReseved)
       );
-      
+
       // there cannot be an Account resource under new_addr already.
       assert!(!exists<Account>(new_address), error::already_exists(EAccountAlreadyExists));      
 

--- a/crates/framework/mos-stdlib/sources/any.move
+++ b/crates/framework/mos-stdlib/sources/any.move
@@ -40,7 +40,7 @@ module mos_std::any {
     /// Unpack a value from the `Any` representation. This aborts if the value has not the expected type `T`.
     public fun unpack<T>(x: Any): T {
         assert!(type_info::type_name<T>() == x.type_name, error::invalid_argument(ETYPE_MISMATCH));
-        bcd::from_bytes<T>(&x.data)
+        bcd::from_bytes<T>(x.data)
     }
 
     /// Returns the type name of this Any

--- a/crates/framework/mos-stdlib/sources/any.move
+++ b/crates/framework/mos-stdlib/sources/any.move
@@ -9,6 +9,7 @@ module mos_std::any {
 
     friend mos_std::copyable_any;
 
+    //TODO unify the Error codes
     /// The type provided for `unpack` is not the same as was given for `pack`.
     const ETYPE_MISMATCH: u64 = 1;
 

--- a/crates/framework/mos-stdlib/sources/bcd.move
+++ b/crates/framework/mos-stdlib/sources/bcd.move
@@ -5,23 +5,23 @@
 /// function because this can violate implicit struct invariants, therefore only primitive types are offerred. If
 /// a general conversion back-and-force is needed, consider the `mos_std::Any` type which preserves invariants.
 module mos_std::bcd{
-    public fun to_bool(v: &vector<u8>): bool {
+    public fun to_bool(v: vector<u8>): bool {
         from_bytes<bool>(v)
     }
 
-    public fun to_u8(v: &vector<u8>): u8 {
+    public fun to_u8(v: vector<u8>): u8 {
         from_bytes<u8>(v)
     }
 
-    public fun to_u64(v: &vector<u8>): u64 {
+    public fun to_u64(v: vector<u8>): u64 {
         from_bytes<u64>(v)
     }
 
-    public fun to_u128(v: &vector<u8>): u128 {
+    public fun to_u128(v: vector<u8>): u128 {
         from_bytes<u128>(v)
     }
 
-    public fun to_address(v: &vector<u8>): address {
+    public fun to_address(v: vector<u8>): address {
         from_bytes<address>(v)
     }
 
@@ -30,7 +30,7 @@ module mos_std::bcd{
     /// Note that this function does not put any constraint on `T`. If code uses this function to
     /// deserialize a linear value, its their responsibility that the data they deserialize is
     /// owned.
-    public(friend) native fun from_bytes<MoveValue>(bytes: &vector<u8>): MoveValue;
+    public(friend) native fun from_bytes<MoveValue>(bytes: vector<u8>): MoveValue;
     friend mos_std::any;
     friend mos_std::copyable_any;
 

--- a/crates/framework/mos-stdlib/sources/copyable_any.move
+++ b/crates/framework/mos-stdlib/sources/copyable_any.move
@@ -28,7 +28,7 @@ module mos_std::copyable_any {
     /// Unpack a value from the `Any` representation. This aborts if the value has not the expected type `T`.
     public fun unpack<T>(x: Any): T {
         assert!(type_info::type_name<T>() == x.type_name, error::invalid_argument(ETYPE_MISMATCH));
-        bcd::from_bytes<T>(&x.data)
+        bcd::from_bytes<T>(x.data)
     }
 
     /// Returns the type name of this Any

--- a/crates/framework/mos-stdlib/sources/copyable_any.move
+++ b/crates/framework/mos-stdlib/sources/copyable_any.move
@@ -7,6 +7,7 @@ module mos_std::copyable_any {
     use std::error;
     use std::string::String;
 
+    //TODO unify the Error codes
     /// The type provided for `unpack` is not the same as was given for `pack`.
     const ETYPE_MISMATCH: u64 = 0;
 

--- a/crates/framework/src/addresses.rs
+++ b/crates/framework/src/addresses.rs
@@ -17,3 +17,8 @@ pub static MOS_STD_ADDRESS: Lazy<AccountAddress> = Lazy::new(|| *MOVE_STD_ADDRES
 pub static MOS_FRAMEWORK_ADDRESS: Lazy<AccountAddress> = Lazy::new(|| *MOVE_STD_ADDRESS);
 pub const MOS_STD_ADDRESS_NAME: &str = "mos_std";
 pub const MOS_FRAMEWORK_ADDRESS_NAME: &str = "mos_framework";
+
+pub static MOS_NAMED_ADDRESS_MAPPING: [(&str, &str); 2] = [
+    (MOS_STD_ADDRESS_NAME, MOS_ADDRESS),
+    (MOS_FRAMEWORK_ADDRESS_NAME, MOS_ADDRESS),
+];

--- a/crates/framework/tests/cases/account/basic.exp
+++ b/crates/framework/tests/cases/account/basic.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/crates/framework/tests/cases/account/basic.move
+++ b/crates/framework/tests/cases/account/basic.move
@@ -1,0 +1,21 @@
+//# init --addresses genesis=0x1 bob=0x42
+
+//TODO create account by faucet
+
+//create account by bob self
+//# run --signers genesis
+script {
+    use mos_framework::account;
+    fun main(_sender: signer) {
+        account::create_account_entry(@bob);
+    }
+}
+
+//check
+//# run --signers bob
+script {
+    use mos_framework::account;
+    fun main(_sender: signer) {
+        assert!(account::exists_at(@bob), 0);
+    }
+}

--- a/crates/framework/tests/tests.rs
+++ b/crates/framework/tests/tests.rs
@@ -1,0 +1,3 @@
+use mos_integration_test_runner::run_test;
+
+datatest_stable::harness!(run_test, "tests", r".*\.(mvir|move)$");

--- a/crates/integration-test-runner/Cargo.toml
+++ b/crates/integration-test-runner/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "moveos-integration-test-runner"
+name = "mos-integration-test-runner"
 version = "0.1.0"
 edition = "2021"
 

--- a/crates/integration-test-runner/tests/cases/call_std.exp
+++ b/crates/integration-test-runner/tests/cases/call_std.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/crates/integration-test-runner/tests/cases/call_std.move
+++ b/crates/integration-test-runner/tests/cases/call_std.move
@@ -1,0 +1,27 @@
+//# init --addresses creator=0x42
+
+//call move_std
+//# run --signers creator
+script {
+    use std::signer;
+
+    fun main(s: signer) {
+        let _addr = signer::address_of(&s);
+    }
+}
+
+
+//call mos_std
+//# run --signers creator
+script {
+    use std::signer;
+    use std::bcs;
+    use mos_std::bcd;
+
+    fun main(s: signer) {
+        let addr = signer::address_of(&s);
+        let bytes = bcs::to_bytes(&addr);
+        let addr2 = bcd::to_address(bytes);
+        assert!(addr == addr2, 0);
+    }
+}

--- a/crates/integration-test-runner/tests/tests.rs
+++ b/crates/integration-test-runner/tests/tests.rs
@@ -1,3 +1,3 @@
-use moveos_integration_test_runner::run_test;
+use mos_integration_test_runner::run_test;
 
 datatest_stable::harness!(run_test, "tests", r".*\.(mvir|move)$");


### PR DESCRIPTION
1. The test-runner auto-generate the genesis module interface.
2. Add test to use `mos_stdlib` in integration tests
3. Fix `bcd::from_bytes` argument bug, use `vector<u8>` to replace `&vector<u8>`. Because we can not cast `ContainerRef` to rust Vec<u8> in MoveVM Value. 
4. Implement the `account::create_account` function, and add tests.

part of #16 