### PR TITLE
[framework] A draft implemention of Object Move

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 resolver = "2"
 
 members = [
+    "crates/mos-types",
     "crates/moveos",
     "crates/statedb",
     "crates/framework",
@@ -29,6 +30,7 @@ rust-version = "1.68"
 [workspace.dependencies]
 # Internal crate dependencies.
 # Please do not add any test features here: they should be declared by the individual crate.
+mos-types = { path = "crates/mos-types" }
 moveos = { path = "crates/moveos" }
 statedb = { path = "crates/statedb" }
 framework = { path = "crates/framework" }
@@ -39,8 +41,10 @@ mos-integration-test-runner = { path = "crates/integration-test-runner" }
 again = "0.1.2"
 anyhow = "1.0.62"
 bcs = "0.1.3"
+better_any = "0.1.1"
 clap = { version = "3", features = ["derive", ] }
 datatest-stable = "0.1.3"
+linked-hash-map = "0.5.6"
 once_cell = "1.10.0"
 serde = { version = "1.0.137", features = ["derive", "rc"] }
 serde_bytes = "0.11.6"
@@ -48,6 +52,7 @@ serde_json = { version = "1.0.81", features = ["preserve_order"] }
 serde_repr = "0.1"
 serde-name = "0.1.1"
 smallvec = "1.6.1"
+thiserror = "1.0.34"
 tokio = { version = "1", features = ["full"] }
 
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,37 +58,37 @@ tokio = { version = "1", features = ["full"] }
 
 # Note: the BEGIN and END comments below are required for external tooling. Do not remove.
 # BEGIN MOVE DEPENDENCIES
-move-abigen = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-binary-format = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-bytecode-verifier = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-bytecode-utils = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-cli = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-command-line-common = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-compiler ={ git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-core-types = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a", features = ["address32"] }
-move-coverage = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-disassembler = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-docgen = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-errmapgen = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-ir-compiler = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-model = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-package = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-prover = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-prover-boogie-backend = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-stackless-bytecode = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-prover-test-utils = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-resource-viewer = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-stackless-bytecode-interpreter = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-stdlib = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a", features = ["address32", "testing"] }
-move-symbol-pool = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-table-extension = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-transactional-test-runner = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-move-unit-test = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a", features = ["table-extension"] }
-move-vm-runtime = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a", features = ["lazy_natives"] }
-move-vm-test-utils = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a", features = ["table-extension"] }
-move-vm-types = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-read-write-set = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-read-write-set-dynamic = { git = "https://github.com/move-language/move", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
+move-abigen = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-binary-format = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-bytecode-verifier = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-bytecode-utils = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-cli = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-command-line-common = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-compiler ={ git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-core-types = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7", features = ["address32"] }
+move-coverage = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-disassembler = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-docgen = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-errmapgen = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-ir-compiler = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-model = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-package = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-prover = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-prover-boogie-backend = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-stackless-bytecode = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-prover-test-utils = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-resource-viewer = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-stackless-bytecode-interpreter = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-stdlib = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7", features = ["address32", "testing"] }
+move-symbol-pool = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-table-extension = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-transactional-test-runner = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+move-unit-test = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7", features = ["table-extension"] }
+move-vm-runtime = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7", features = ["lazy_natives"] }
+move-vm-test-utils = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7", features = ["table-extension"] }
+move-vm-types = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+read-write-set = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+read-write-set-dynamic = { git = "https://github.com/rooch-network/move", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
 # END MOVE DEPENDENCIES
 
 smt = { git = "https://github.com/rooch-network/smt", rev = "bba62b6e82b3ed81f1c27a2f6f36a017315cdf0a" }

--- a/crates/framework/Cargo.toml
+++ b/crates/framework/Cargo.toml
@@ -7,6 +7,8 @@ edition = "2021"
 
 [dependencies]
 anyhow = { workspace = true }
+better_any = { workspace = true }
+linked-hash-map = { workspace = true }
 once_cell = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
@@ -25,6 +27,8 @@ move-vm-test-utils = { workspace = true }
 move-vm-types = { workspace = true }
 move-package = { workspace = true }
 move-prover = { workspace = true }
+
+mos-types = { workspace = true }
 
 [dev-dependencies]
 mos-integration-test-runner = { workspace = true }

--- a/crates/framework/mos-stdlib/Move.toml
+++ b/crates/framework/mos-stdlib/Move.toml
@@ -8,5 +8,5 @@ mos_std = "0x1"
 
 [dependencies]
 #MoveStdlib = { local = "../move-stdlib" }
-MoveStdlib = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
-MoveNursery = { git = "https://github.com/move-language/move.git", subdir = "language/move-stdlib/nursery", rev = "47bb63611844e547fed85c9fe7f66d508caa684a" }
+MoveStdlib = { git = "https://github.com/rooch-network/move.git", subdir = "language/move-stdlib", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }
+MoveNursery = { git = "https://github.com/rooch-network/move.git", subdir = "language/move-stdlib/nursery", rev = "5b413d009515ad1144042ded27cbe9bd702aaad7" }

--- a/crates/framework/mos-stdlib/sources/address.move
+++ b/crates/framework/mos-stdlib/sources/address.move
@@ -1,0 +1,64 @@
+//Source https://github.com/MystenLabs/sui/blob/598f106ef5fbdfbe1b644236f0caf46c94f4d1b7/crates/sui-framework/sources/address.move
+
+module mos_std::address {
+    use std::ascii;
+    use std::bcs;
+    use mos_std::hex;
+    use mos_std::bcd;
+
+    /// The length of an address, in bytes
+    const LENGTH: u64 = 32;
+
+    // The largest integer that can be represented with 32 bytes
+    const MAX: u256 = 115792089237316195423570985008687907853269984665640564039457584007913129639935;
+
+    /// Error from `from_bytes` when it is supplied too many or too few bytes.
+    const EAddressParseError: u64 = 0;
+
+    /// Error from `from_u256` when
+    const EU256TooBigToConvertToAddress: u64 = 1;
+
+    //TODO
+    /// Convert `a` into a u256 by interpreting `a` as the bytes of a big-endian integer
+    /// (e.g., `to_u256(0x1) == 1`)
+    //public native fun to_u256(a: address): u256;
+
+    //TODO
+    /// Convert `n` into an address by encoding it as a big-endian integer (e.g., `from_u256(1) = @0x1`)
+    /// Aborts if `n` > `MAX_ADDRESS`
+    //public native fun from_u256(n: u256): address;
+
+    /// Convert `bytes` into an address.
+    /// Aborts with `EAddressParseError` if the length of `bytes` is invalid length
+    public fun from_bytes(bytes: vector<u8>): address{
+        bcd::to_address(bytes)
+    }
+
+
+    /// Convert `a` into BCS-encoded bytes.
+    public fun to_bytes(a: address): vector<u8> {
+        bcs::to_bytes(&a)
+    }
+
+    /// Convert `a` to a hex-encoded ASCII string
+    public fun to_ascii_string(a: address): ascii::String {
+        ascii::string(hex::encode(to_bytes(a)))
+    }
+
+    /// Convert `a` to a hex-encoded ASCII string
+    //TODO add `from_ascii` to string module
+    // public fun to_string(a: address): string::String {
+    //     string::from_ascii(to_ascii_string(a))
+    // }
+
+    /// Length of a Sui address in bytes
+    public fun length(): u64 {
+        LENGTH
+    }
+
+    /// Largest possible address
+    public fun max(): u256 {
+        MAX
+    }
+
+}

--- a/crates/framework/mos-stdlib/sources/hex.move
+++ b/crates/framework/mos-stdlib/sources/hex.move
@@ -1,0 +1,113 @@
+// Source https://github.com/MystenLabs/sui/blob/598f106ef5fbdfbe1b644236f0caf46c94f4d1b7/crates/sui-framework/sources/hex.move
+
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+/// HEX (Base16) encoding utility.
+module mos_std::hex {
+    use std::vector;
+
+    const EInvalidHexLength: u64 = 0;
+    const ENotValidHexCharacter: u64 = 1;
+
+    /// Vector of Base16 values from `00` to `FF`
+    const HEX: vector<vector<u8>> = vector[
+        b"00",b"01",b"02",b"03",b"04",b"05",b"06",b"07",b"08",b"09",b"0a",b"0b",b"0c",b"0d",b"0e",b"0f",b"10",b"11",b"12",b"13",b"14",b"15",b"16",b"17",b"18",b"19",b"1a",b"1b",b"1c",b"1d",b"1e",b"1f",b"20",b"21",b"22",b"23",b"24",b"25",b"26",b"27",b"28",b"29",b"2a",b"2b",b"2c",b"2d",b"2e",b"2f",b"30",b"31",b"32",b"33",b"34",b"35",b"36",b"37",b"38",b"39",b"3a",b"3b",b"3c",b"3d",b"3e",b"3f",b"40",b"41",b"42",b"43",b"44",b"45",b"46",b"47",b"48",b"49",b"4a",b"4b",b"4c",b"4d",b"4e",b"4f",b"50",b"51",b"52",b"53",b"54",b"55",b"56",b"57",b"58",b"59",b"5a",b"5b",b"5c",b"5d",b"5e",b"5f",b"60",b"61",b"62",b"63",b"64",b"65",b"66",b"67",b"68",b"69",b"6a",b"6b",b"6c",b"6d",b"6e",b"6f",b"70",b"71",b"72",b"73",b"74",b"75",b"76",b"77",b"78",b"79",b"7a",b"7b",b"7c",b"7d",b"7e",b"7f",b"80",b"81",b"82",b"83",b"84",b"85",b"86",b"87",b"88",b"89",b"8a",b"8b",b"8c",b"8d",b"8e",b"8f",b"90",b"91",b"92",b"93",b"94",b"95",b"96",b"97",b"98",b"99",b"9a",b"9b",b"9c",b"9d",b"9e",b"9f",b"a0",b"a1",b"a2",b"a3",b"a4",b"a5",b"a6",b"a7",b"a8",b"a9",b"aa",b"ab",b"ac",b"ad",b"ae",b"af",b"b0",b"b1",b"b2",b"b3",b"b4",b"b5",b"b6",b"b7",b"b8",b"b9",b"ba",b"bb",b"bc",b"bd",b"be",b"bf",b"c0",b"c1",b"c2",b"c3",b"c4",b"c5",b"c6",b"c7",b"c8",b"c9",b"ca",b"cb",b"cc",b"cd",b"ce",b"cf",b"d0",b"d1",b"d2",b"d3",b"d4",b"d5",b"d6",b"d7",b"d8",b"d9",b"da",b"db",b"dc",b"dd",b"de",b"df",b"e0",b"e1",b"e2",b"e3",b"e4",b"e5",b"e6",b"e7",b"e8",b"e9",b"ea",b"eb",b"ec",b"ed",b"ee",b"ef",b"f0",b"f1",b"f2",b"f3",b"f4",b"f5",b"f6",b"f7",b"f8",b"f9",b"fa",b"fb",b"fc",b"fd",b"fe",b"ff"
+    ];
+
+    /// Encode `bytes` in lowercase hex
+    public fun encode(bytes: vector<u8>): vector<u8> {
+        let (i, r, l) = (0, vector[], vector::length(&bytes));
+        while (i < l) {
+            vector::append(
+                &mut r, 
+                *vector::borrow(&HEX, (*vector::borrow(&bytes, i) as u64))
+            );
+            i = i + 1;
+        };
+        r
+    }
+
+    /// Decode hex into `bytes`
+    /// Takes a hex string (no 0x prefix) (e.g. b"0f3a")
+    /// Returns vector of `bytes` that represents the hex string (e.g. x"0f3a")
+    /// Hex string can be case insensitive (e.g. b"0F3A" and b"0f3a" both return x"0f3a")
+    /// Aborts if the hex string does not have an even number of characters (as each hex character is 2 characters long)
+    /// Aborts if the hex string contains non-valid hex characters (valid characters are 0 - 9, a - f, A - F)
+    public fun decode(hex: vector<u8>): vector<u8> {
+        let (i, r, l) = (0, vector[], vector::length(&hex));
+        assert!(l % 2 == 0, EInvalidHexLength); 
+        while (i < l) {
+            let decimal = (decode_byte(*vector::borrow(&hex, i)) * 16) + 
+                          decode_byte(*vector::borrow(&hex, i + 1));
+            vector::push_back(&mut r, decimal);
+            i = i + 2;
+        };
+        r
+    }
+    
+    fun decode_byte(hex: u8): u8 {
+        if (/* 0 .. 9 */ 48 <= hex && hex < 58) {
+            hex - 48
+        } else if (/* A .. F */ 65 <= hex && hex < 71) {
+            10 + hex - 65
+        } else if (/* a .. f */ 97 <= hex && hex < 103) {
+            10 + hex - 97
+        } else {
+            abort ENotValidHexCharacter
+        }
+    }
+
+    spec module { pragma verify = false; }
+
+    #[test]
+    fun test_hex_encode_string_literal() {
+        assert!(b"30" == encode(b"0"), 0);
+        assert!(b"61" == encode(b"a"), 0);       
+        assert!(b"666666" == encode(b"fff"), 0);
+    }
+
+    #[test]
+    fun test_hex_encode_hex_literal() {
+        assert!(b"ff" == encode(x"ff"), 0);
+        assert!(b"fe" == encode(x"fe"), 0);
+        assert!(b"00" == encode(x"00"), 0);
+    }
+
+    #[test]
+    fun test_hex_decode_string_literal() {
+        assert!(x"ff" == decode(b"ff"), 0);
+        assert!(x"fe" == decode(b"fe"), 0);
+        assert!(x"00" == decode(b"00"), 0);
+    }
+
+    #[test]
+    fun test_hex_decode_string_literal__lowercase_and_uppercase() {
+        assert!(x"ff" == decode(b"Ff"), 0);
+        assert!(x"ff" == decode(b"fF"), 0);
+        assert!(x"ff" == decode(b"FF"), 0);
+    }
+
+    #[test]
+    fun test_hex_decode_string_literal__long_hex() {
+        assert!(x"036d2416252ae1db8aedad59e14b007bee6ab94a3e77a3549a81137871604456f3" == decode(b"036d2416252ae1Db8aedAd59e14b007bee6aB94a3e77a3549a81137871604456f3"), 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = EInvalidHexLength)]
+    fun test_hex_decode__invalid_length() {
+        decode(b"0");
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ENotValidHexCharacter)]
+    fun test_hex_decode__hex_literal() {
+        decode(x"ffff");
+    }
+
+    #[test]
+    #[expected_failure(abort_code = ENotValidHexCharacter)]
+    fun test_hex_decode__invalid_string_literal() {
+        decode(b"0g");
+    }
+}

--- a/crates/framework/mos-stdlib/sources/object.move
+++ b/crates/framework/mos-stdlib/sources/object.move
@@ -1,0 +1,160 @@
+/// origin source from https://github.com/MystenLabs/sui/blob/598f106ef5fbdfbe1b644236f0caf46c94f4d1b7/crates/sui-framework/sources/object.move#L75
+
+/// Move object identifiers
+module mos_std::object {
+    use std::bcs;
+    use mos_std::address;
+    use mos_std::tx_context::{Self, TxContext};
+
+    /// An object ID. This is used to reference Sui Objects.
+    /// This is *not* guaranteed to be globally unique--anyone can create an `ID` from a `UID` or
+    /// from an object, and ID's can be freely copied and dropped.
+    /// Here, the values are not globally unique because there can be multiple values of type `ID`
+    /// with the same underlying bytes. For example, `object::id(&obj)` can be called as many times
+    /// as you want for a given `obj`, and each `ID` value will be identical.
+    struct ID has copy, drop, store {
+        // We use `address` instead of `vector<u8>` here because `address` has a more
+        // compact serialization. `address` is serialized as a BCS fixed-length sequence,
+        // which saves us the length prefix we would pay for if this were `vector<u8>`.
+        // See https://github.com/diem/bcs#fixed-and-variable-length-sequences.
+        bytes: address
+    }
+
+    /// Globally unique IDs that define an object's ID in storage. Any Sui Object, that is a struct
+    /// with the `key` ability, must have `id: UID` as its first field.
+    /// These are globally unique in the sense that no two values of type `UID` are ever equal, in
+    /// other words for any two values `id1: UID` and `id2: UID`, `id1` != `id2`.
+    /// This is a privileged type that can only be derived from a `TxContext`.
+    /// `UID` doesn't have the `drop` ability, so deleting a `UID` requires a call to `delete`.
+    struct UID has store {
+        id: ID,
+    }
+
+    // === id ===
+
+    /// Get the raw bytes of a `ID`
+    public fun id_to_bytes(id: &ID): vector<u8> {
+        bcs::to_bytes(&id.bytes)
+    }
+
+    /// Get the inner bytes of `id` as an address.
+    public fun id_to_address(id: &ID): address {
+        id.bytes
+    }
+
+    /// Make an `ID` from raw bytes.
+    public fun id_from_bytes(bytes: vector<u8>): ID {
+        id_from_address(address::from_bytes(bytes))
+    }
+
+    /// Make an `ID` from an address.
+    public fun id_from_address(bytes: address): ID {
+        ID { bytes }
+    }
+
+    // === uid ===
+
+    /// Get the inner `ID` of `uid`
+    public fun uid_as_inner(uid: &UID): &ID {
+        &uid.id
+    }
+
+    /// Get the raw bytes of a `uid`'s inner `ID`
+    public fun uid_to_inner(uid: &UID): ID {
+        uid.id
+    }
+
+    /// Get the raw bytes of a `UID`
+    public fun uid_to_bytes(uid: &UID): vector<u8> {
+        bcs::to_bytes(&uid.id.bytes)
+    }
+
+    /// Get the inner bytes of `id` as an address.
+    public fun uid_to_address(uid: &UID): address {
+        uid.id.bytes
+    }
+
+    // === any object ===
+
+    /// Create a new object. Returns the `UID` that must be stored in a Sui object.
+    /// This is the only way to create `UID`s.
+    public fun new(ctx: &mut TxContext): UID {
+        UID {
+            id: ID { bytes: tx_context::new_object(ctx) },
+        }
+    }
+
+    /// Delete the object and it's `UID`. This is the only way to eliminate a `UID`.
+    // This exists to inform Sui of object deletions. When an object
+    // gets unpacked, the programmer will have to do something with its
+    // `UID`. The implementation of this function emits a deleted
+    // system event so Sui knows to process the object deletion
+    public fun delete(id: UID) {
+        let UID { id: ID { bytes } } = id;
+        delete_impl(bytes)
+    }
+
+    /// Get the underlying `ID` of `obj`
+    public fun id<T: key>(obj: &T): ID {
+        borrow_uid(obj).id
+    }
+
+    /// Borrow the underlying `ID` of `obj`
+    public fun borrow_id<T: key>(obj: &T): &ID {
+        &borrow_uid(obj).id
+    }
+
+    /// Get the raw bytes for the underlying `ID` of `obj`
+    public fun id_bytes<T: key>(obj: &T): vector<u8> {
+        bcs::to_bytes(&borrow_uid(obj).id)
+    }
+
+    /// Get the inner bytes for the underlying `ID` of `obj`
+    public fun id_address<T: key>(obj: &T): address {
+        borrow_uid(obj).id.bytes
+    }
+
+    /// Get the `UID` for `obj`.
+    /// Safe because Sui has an extra bytecode verifier pass that forces every struct with
+    /// the `key` ability to have a distinguished `UID` field.
+    /// Cannot be made public as the access to `UID` for a given object must be privileged, and
+    /// restrictable in the object's module.
+    native fun borrow_uid<T: key>(obj: &T): &UID;
+
+    // /// Generate a new UID specifically used for creating a UID from a hash
+    // public(friend) fun new_uid_from_hash(bytes: address): UID {
+    //     record_new_uid(bytes);
+    //     UID { id: ID { bytes } }
+    // }
+
+    // helper for delete
+    native fun delete_impl(id: address);
+
+    //TODO we need this?
+    // marks newly created UIDs from hash
+    //native fun record_new_uid(id: address);
+
+    // === transfer functions ===
+    //https://github.com/MystenLabs/sui/blob/598f106ef5fbdfbe1b644236f0caf46c94f4d1b7/crates/sui-framework/sources/transfer.move#L92
+
+   
+    /// Transfer ownership of `obj` to `recipient`. `obj` must have the
+    /// `key` attribute, which (in turn) ensures that `obj` has a globally
+    /// unique ID.
+    public fun transfer<T: key>(obj: T, recipient: address) {
+        // TODO: emit event
+        transfer_internal(obj, recipient)
+    }
+
+    /// Freeze `obj`. After freezing `obj` becomes immutable and can no
+    /// longer be transferred or mutated.
+    public native fun freeze_object<T: key>(obj: T);
+
+    /// Turn the given object into a mutable shared object that everyone
+    /// can access and mutate. This is irreversible, i.e. once an object
+    /// is shared, it will stay shared forever.
+    public native fun share_object<T: key>(obj: T);
+
+    native fun transfer_internal<T: key>(obj: T, recipient: address);
+
+}

--- a/crates/framework/mos-stdlib/sources/tx_context.move
+++ b/crates/framework/mos-stdlib/sources/tx_context.move
@@ -1,4 +1,5 @@
 // Origin source https://github.com/MystenLabs/sui/blob/598f106ef5fbdfbe1b644236f0caf46c94f4d1b7/crates/sui-framework/sources/tx_context.move#L24
+// And do refactoring
 
 module mos_std::tx_context {
 
@@ -28,14 +29,25 @@ module mos_std::tx_context {
     /// transaction
     public fun sender(self: &TxContext): address {
         self.sender
-    }
+    } 
 
-    /// Generate a new, globally unique object ID with version 0
+      /// Generate a new, globally unique object ID with version 0
     public(friend) fun new_object(ctx: &mut TxContext): address {
         let ids_created = ctx.ids_created;
+        //Can we derive_id in Move?
         let id = derive_id(*&ctx.tx_hash, ids_created);
         ctx.ids_created = ids_created + 1;
         id
+    }
+    
+    //TODO should support make signer with TxContext?
+    // pub fun sender_signer(self: &TxContext): &signer {
+    //     
+    //}
+
+    /// Return the hash of the current transaction
+    public fun tx_hash(self: &TxContext): vector<u8> {
+        self.tx_hash
     }
 
     /// Return the number of id's created by the current transaction.
@@ -44,6 +56,7 @@ module mos_std::tx_context {
         self.ids_created
     }
 
+    /// Should move this function to Object?
     /// Native function for deriving an ID via hash(tx_hash || ids_created)
     native fun derive_id(tx_hash: vector<u8>, ids_created: u64): address;
 

--- a/crates/framework/mos-stdlib/sources/tx_context.move
+++ b/crates/framework/mos-stdlib/sources/tx_context.move
@@ -1,0 +1,50 @@
+// Origin source https://github.com/MystenLabs/sui/blob/598f106ef5fbdfbe1b644236f0caf46c94f4d1b7/crates/sui-framework/sources/tx_context.move#L24
+
+module mos_std::tx_context {
+
+    friend mos_std::object;
+
+    /// Number of bytes in an tx hash (which will be the transaction digest)
+    const TX_HASH_LENGTH: u64 = 32;
+
+    /// Expected an tx hash of length 32, but found a different length
+    const EBadTxHashLength: u64 = 0;
+
+
+    /// Information about the transaction currently being executed.
+    /// This cannot be constructed by a transaction--it is a privileged object created by
+    /// the VM and passed in to the entrypoint of the transaction as `&mut TxContext`.
+    struct TxContext has drop {
+        /// The address of the user that signed the current transaction
+        sender: address,
+        /// Hash of the current transaction
+        tx_hash: vector<u8>,
+        /// Counter recording the number of fresh id's created while executing
+        /// this transaction. Always 0 at the start of a transaction
+        ids_created: u64
+    }
+
+    /// Return the address of the user that signed the current
+    /// transaction
+    public fun sender(self: &TxContext): address {
+        self.sender
+    }
+
+    /// Generate a new, globally unique object ID with version 0
+    public(friend) fun new_object(ctx: &mut TxContext): address {
+        let ids_created = ctx.ids_created;
+        let id = derive_id(*&ctx.tx_hash, ids_created);
+        ctx.ids_created = ids_created + 1;
+        id
+    }
+
+    /// Return the number of id's created by the current transaction.
+    /// Hidden for now, but may expose later
+    fun ids_created(self: &TxContext): u64 {
+        self.ids_created
+    }
+
+    /// Native function for deriving an ID via hash(tx_hash || ids_created)
+    native fun derive_id(tx_hash: vector<u8>, ids_created: u64): address;
+
+}

--- a/crates/framework/src/natives/helpers.rs
+++ b/crates/framework/src/natives/helpers.rs
@@ -1,7 +1,15 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use move_vm_runtime::native_functions::NativeFunction;
+use move_binary_format::errors::PartialVMResult;
+use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, values::Value,
+};
+use std::{collections::VecDeque, sync::Arc};
 
 pub fn make_module_natives(
     natives: impl IntoIterator<Item = (impl Into<String>, NativeFunction)>,
@@ -9,4 +17,21 @@ pub fn make_module_natives(
     natives
         .into_iter()
         .map(|(func_name, func)| (func_name.into(), func))
+}
+
+pub fn make_native<G>(
+    gas_params: G,
+    func: impl Fn(&G, &mut NativeContext, Vec<Type>, VecDeque<Value>) -> PartialVMResult<NativeResult>
+        + Sync
+        + Send
+        + 'static,
+) -> NativeFunction
+where
+    G: Send + Sync + 'static,
+{
+    Arc::new(
+        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+            func(&gas_params, context, ty_args, args)
+        },
+    )
 }

--- a/crates/framework/src/natives/mod.rs
+++ b/crates/framework/src/natives/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::addresses::{MOS_STD_ADDRESS, MOVE_STD_ADDRESS};
+use move_core_types::gas_algebra::InternalGas;
 use move_vm_runtime::native_functions::{make_table_from_iter, NativeFunctionTable};
 
 mod helpers;
@@ -17,6 +18,8 @@ pub struct GasParameters {
     rlp: mos_stdlib::rlp::GasParameters,
     account: mos_framework::account::GasParameters,
     bcd: mos_stdlib::bcd::GasParameters,
+    tx_context: mos_stdlib::tx_context::GasParameters,
+    object: mos_stdlib::object::GasParameters,
 }
 
 impl GasParameters {
@@ -29,6 +32,22 @@ impl GasParameters {
             rlp: mos_stdlib::rlp::GasParameters::zeros(),
             account: mos_framework::account::GasParameters::zeros(),
             bcd: mos_stdlib::bcd::GasParameters::zeros(),
+            tx_context: mos_stdlib::tx_context::GasParameters::zeros(),
+            object: mos_stdlib::object::GasParameters::zeros(),
+        }
+    }
+}
+
+/// A fixed base gas cost for a native function.
+#[derive(Debug, Clone)]
+pub struct BaseGasParameter {
+    pub base: InternalGas,
+}
+
+impl BaseGasParameter {
+    pub fn zeros() -> Self {
+        Self {
+            base: InternalGas::new(0),
         }
     }
 }
@@ -62,6 +81,11 @@ pub fn all_natives(gas_params: GasParameters) -> NativeFunctionTable {
     );
     add_natives!("rlp", mos_stdlib::rlp::make_all(gas_params.rlp));
     add_natives!("bcd", mos_stdlib::bcd::make_all(gas_params.bcd));
+    add_natives!(
+        "tx_context",
+        mos_stdlib::tx_context::make_all(gas_params.tx_context)
+    );
+    add_natives!("object", mos_stdlib::object::make_all(gas_params.object));
 
     // mos_framework natives
     add_natives!(

--- a/crates/framework/src/natives/mos_stdlib/mod.rs
+++ b/crates/framework/src/natives/mos_stdlib/mod.rs
@@ -5,5 +5,5 @@ pub mod bcd;
 pub mod object;
 pub mod object_extension;
 pub mod rlp;
-pub mod tx_context;
 pub mod type_info;
+pub mod tx_context;

--- a/crates/framework/src/natives/mos_stdlib/mod.rs
+++ b/crates/framework/src/natives/mos_stdlib/mod.rs
@@ -5,5 +5,5 @@ pub mod bcd;
 pub mod object;
 pub mod object_extension;
 pub mod rlp;
-pub mod type_info;
 pub mod tx_context;
+pub mod type_info;

--- a/crates/framework/src/natives/mos_stdlib/object.rs
+++ b/crates/framework/src/natives/mos_stdlib/object.rs
@@ -13,11 +13,11 @@ use crate::natives::{
     mos_stdlib::object_extension::NativeObjectContext,
     BaseGasParameter,
 };
-use mos_types::object::{Owner};
+use mos_types::object::Owner;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
-    account_address::AccountAddress, language_storage::TypeTag,
-    value::MoveTypeLayout, vm_status::StatusCode,
+    account_address::AccountAddress, language_storage::TypeTag, value::MoveTypeLayout,
+    vm_status::StatusCode,
 };
 use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
 use move_vm_types::{
@@ -28,7 +28,6 @@ use move_vm_types::{
 };
 use smallvec::smallvec;
 use std::collections::VecDeque;
-
 
 pub type BorrowUidGasParameter = BaseGasParameter;
 

--- a/crates/framework/src/natives/mos_stdlib/object.rs
+++ b/crates/framework/src/natives/mos_stdlib/object.rs
@@ -1,0 +1,224 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Source from https://github.com/MystenLabs/sui/blob/598f106ef5fbdfbe1b644236f0caf46c94f4d1b7/crates/sui-framework/src/natives/object.rs
+// and do some refactor
+
+use super::object_extension::TransferResult;
+use crate::natives::{
+    helpers::{make_module_natives, make_native},
+    mos_stdlib::object_extension::NativeObjectContext,
+    BaseGasParameter,
+};
+use mos_types::object::Owner;
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{
+    account_address::AccountAddress, language_storage::TypeTag, vm_status::StatusCode,
+};
+use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    natives::function::NativeResult,
+    pop_arg,
+    values::{StructRef, Value},
+};
+use smallvec::smallvec;
+use std::collections::VecDeque;
+
+pub type BorrowUidGasParameter = BaseGasParameter;
+
+// native fun borrow_uid<T: key>(obj: &T): &UID;
+pub fn native_borrow_uid(
+    gas_param: &BorrowUidGasParameter,
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let obj = pop_arg!(args, StructRef);
+    let id_field = obj.borrow_field(0)?;
+    //TODO check the id_field type.
+
+    // TODO: what should the cost of this be?
+    let cost = gas_param.base;
+
+    Ok(NativeResult::ok(cost, smallvec![id_field]))
+}
+
+pub type DeleteGasParameter = BaseGasParameter;
+
+// native fun delete_impl(id: address);
+pub fn native_delete_impl(
+    gas_param: &DeleteGasParameter,
+    context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 1);
+
+    // unwrap safe because the interface of native function guarantees it.
+    let uid_bytes = pop_arg!(args, AccountAddress);
+
+    // TODO: what should the cost of this be?
+    let cost = gas_param.base;
+
+    let obj_runtime: &mut NativeObjectContext = context.extensions_mut().get_mut();
+    obj_runtime.delete_id(uid_bytes.into())?;
+    Ok(NativeResult::ok(cost, smallvec![]))
+}
+
+// We make the transfer function with object native function together.
+// https://github.com/MystenLabs/sui/blob/598f106ef5fbdfbe1b644236f0caf46c94f4d1b7/crates/sui-framework/src/natives/transfer.rs
+
+pub type TransferGasParameter = BaseGasParameter;
+
+/// Implementation of Move native function
+/// `transfer_internal<T: key>(obj: T, recipient: address)`
+pub fn native_transfer_internal(
+    gas_param: &TransferGasParameter,
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 2);
+
+    let ty = ty_args.pop().unwrap();
+    let recipient = pop_arg!(args, AccountAddress);
+    let obj = args.pop_back().unwrap();
+    let owner = Owner::AddressOwner(recipient);
+    object_runtime_transfer(context, owner, ty, obj)?;
+    // Charge a constant native gas cost here, since
+    // we will charge it properly when processing
+    // all the events in adapter.
+    // TODO: adjust native_gas cost size base.
+    let cost = gas_param.base;
+    Ok(NativeResult::ok(cost, smallvec![]))
+}
+
+pub type FreezeGasParameter = BaseGasParameter;
+
+/// Implementation of Move native function
+/// `freeze_object<T: key>(obj: T)`
+pub fn native_freeze_object(
+    gas_param: &FreezeGasParameter,
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let ty = ty_args.pop().unwrap();
+    let obj = args.pop_back().unwrap();
+    object_runtime_transfer(context, Owner::Immutable, ty, obj)?;
+    let cost = gas_param.base;
+    Ok(NativeResult::ok(cost, smallvec![]))
+}
+
+pub type ShareGasParameter = BaseGasParameter;
+
+/// Implementation of Move native function
+/// `share_object<T: key>(obj: T)`
+pub fn native_share_object(
+    gas_param: &ShareGasParameter,
+    context: &mut NativeContext,
+    mut ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.len() == 1);
+    debug_assert!(args.len() == 1);
+
+    let ty = ty_args.pop().unwrap();
+    let obj = args.pop_back().unwrap();
+    let _transfer_result = object_runtime_transfer(
+        context,
+        // Dummy version, to be filled with the correct initial version when the effects of the
+        // transaction are written to storage.
+        Owner::Shared {
+            initial_shared_version: 0,
+        },
+        ty,
+        obj,
+    )?;
+    let cost = gas_param.base;
+    //TODO check the transfer_result
+    Ok(NativeResult::ok(cost, smallvec![]))
+}
+
+fn object_runtime_transfer(
+    context: &mut NativeContext,
+    owner: Owner,
+    ty: Type,
+    obj: Value,
+) -> PartialVMResult<TransferResult> {
+    let tag = match context.type_to_type_tag(&ty)? {
+        TypeTag::Struct(s) => s,
+        _ => {
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                    .with_message("verifier guarantees this is a struct".to_string()),
+            )
+        }
+    };
+    let obj_runtime: &mut NativeObjectContext = context.extensions_mut().get_mut();
+    obj_runtime.transfer(owner, ty, *tag, obj)
+}
+
+/***************************************************************************************************
+ * module
+ **************************************************************************************************/
+
+#[derive(Debug, Clone)]
+pub struct GasParameters {
+    pub borrow_uid: BorrowUidGasParameter,
+    pub delete: DeleteGasParameter,
+    pub transfer: TransferGasParameter,
+    pub freeze: FreezeGasParameter,
+    pub share: ShareGasParameter,
+}
+
+impl GasParameters {
+    pub fn zeros() -> Self {
+        Self {
+            borrow_uid: BorrowUidGasParameter::zeros(),
+            delete: DeleteGasParameter::zeros(),
+            transfer: TransferGasParameter::zeros(),
+            freeze: FreezeGasParameter::zeros(),
+            share: ShareGasParameter::zeros(),
+        }
+    }
+}
+
+pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
+    let natives = [
+        (
+            "borrow_uid",
+            make_native(gas_params.borrow_uid, native_borrow_uid),
+        ),
+        (
+            "delete_impl",
+            make_native(gas_params.delete, native_delete_impl),
+        ),
+        (
+            "transfer_internal",
+            make_native(gas_params.transfer, native_transfer_internal),
+        ),
+        (
+            "freeze_object",
+            make_native(gas_params.freeze, native_freeze_object),
+        ),
+        (
+            "share_object",
+            make_native(gas_params.share, native_share_object),
+        ),
+    ];
+
+    make_module_natives(natives)
+}

--- a/crates/framework/src/natives/mos_stdlib/object_extension/mod.rs
+++ b/crates/framework/src/natives/mos_stdlib/object_extension/mod.rs
@@ -1,0 +1,151 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use better_any::{Tid, TidAble};
+use mos_types::object::{Object, ObjectID, Owner};
+use move_binary_format::errors::PartialVMError;
+use move_core_types::{
+    account_address::AccountAddress, language_storage::StructTag, vm_status::StatusCode,
+};
+use move_vm_types::{
+    loaded_data::runtime_types::Type,
+    values::{Struct, Value},
+};
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet},
+};
+
+/// A table resolver which needs to be provided by the environment. This allows to lookup
+/// data in remote storage, as well as retrieve cost of table operations.
+pub trait ObjectResolver {
+    fn resolve_object(&self, object_id: ObjectID) -> Result<Option<Object>, anyhow::Error>;
+
+    // fn delete_object(&self,
+    //     object_id: ObjectID,
+    // ) -> Result<(), anyhow::Error>;
+}
+
+pub enum TransferResult {
+    New,
+    SameOwner,
+    OwnerChanged,
+}
+/// The native object context extension. This needs to be attached to the NativeContextExtensions
+/// value which is passed into session functions, so its accessible from natives of this
+/// extension.
+#[derive(Tid)]
+pub struct NativeObjectContext<'a> {
+    resolver: &'a dyn ObjectResolver,
+    object_data: RefCell<ObjectData>,
+}
+
+impl<'a> NativeObjectContext<'a> {
+    pub fn new(resolver: &'a dyn ObjectResolver) -> Self {
+        Self {
+            resolver,
+            object_data: RefCell::new(ObjectData::default()),
+        }
+    }
+
+    pub fn get_object(&self, object_id: ObjectID) -> Result<Option<Object>, PartialVMError> {
+        let object_data = self.object_data.borrow();
+        //TODO need to check the transfers
+        // if let Some(object) = object_data.transfers.get(&object_id) {
+        //     return Ok(Some(object.clone()));
+        // }
+        if object_data.removed_object.contains(&object_id) {
+            return Ok(None);
+        }
+        if object_data.new_object_ids.contains(&object_id) {
+            return Ok(None);
+        }
+        let object = self.resolver.resolve_object(object_id).map_err(|e| {
+            PartialVMError::new(StatusCode::STORAGE_ERROR).with_message(format!("{:?}", e))
+        })?;
+        Ok(object)
+    }
+
+    pub fn delete_id(&self, object_id: ObjectID) -> Result<(), PartialVMError> {
+        let mut object_data = self.object_data.borrow_mut();
+        object_data.removed_object.insert(object_id);
+        Ok(())
+    }
+
+    pub(crate) fn transfer(
+        &self,
+        owner: Owner,
+        ty: Type,
+        tag: StructTag,
+        obj: Value,
+    ) -> Result<TransferResult, PartialVMError> {
+        let mut object_data = self.object_data.borrow_mut();
+        let object_id: ObjectID = get_object_id(obj.copy_value()?)?
+            .value_as::<AccountAddress>()?
+            .into();
+        object_data
+            .transfers
+            .insert(object_id, ObjectInfo::new(owner, ty, tag, obj));
+        //TODO return the correct result
+        Ok(TransferResult::New)
+    }
+}
+
+#[derive(Debug)]
+pub struct ObjectInfo {
+    pub owner: Owner,
+    pub ty: Type,
+    pub tag: StructTag,
+    pub value: Value,
+}
+
+impl ObjectInfo {
+    pub fn new(owner: Owner, ty: Type, tag: StructTag, value: Value) -> Self {
+        Self {
+            owner,
+            ty,
+            tag,
+            value,
+        }
+    }
+}
+
+impl std::fmt::Display for ObjectInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ObjectInfo({:?}, {:?}, {:?}, {:?})",
+            self.owner, self.ty, self.tag, self.value
+        )
+    }
+}
+
+/// A structure representing mutable data of the NativeTableContext. This is in a RefCell
+/// of the overall context so we can mutate while still accessing the overall context.
+#[derive(Default)]
+struct ObjectData {
+    new_object_ids: BTreeSet<ObjectID>,
+    removed_object: BTreeSet<ObjectID>,
+    transfers: BTreeMap<ObjectID, ObjectInfo>,
+}
+
+// Object { id: UID { id: ID { bytes: address } } .. }
+// Extract the first field of the struct 3 times to get the id bytes.
+pub fn get_object_id(object: Value) -> Result<Value, PartialVMError> {
+    get_nested_struct_field(object, &[0, 0, 0])
+}
+
+// Extract a field valye that's nested inside value `v`. The offset of each nesting
+// is determined by `offsets`.
+pub fn get_nested_struct_field(mut v: Value, offsets: &[usize]) -> Result<Value, PartialVMError> {
+    for offset in offsets {
+        v = get_nth_struct_field(v, *offset)?;
+    }
+    Ok(v)
+}
+
+pub fn get_nth_struct_field(v: Value, n: usize) -> Result<Value, PartialVMError> {
+    let mut itr = v.value_as::<Struct>()?.unpack()?;
+    Ok(itr.nth(n).unwrap())
+}

--- a/crates/framework/src/natives/mos_stdlib/tx_context.rs
+++ b/crates/framework/src/natives/mos_stdlib/tx_context.rs
@@ -1,0 +1,85 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+// Copyright (c) Mysten Labs, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Source from https://github.com/MystenLabs/sui/blob/598f106ef5fbdfbe1b644236f0caf46c94f4d1b7/crates/sui-framework/src/natives/tx_context.rs
+// and do some refactor
+
+use mos_types::object::ObjectID;
+use move_binary_format::errors::PartialVMResult;
+use move_core_types::gas_algebra::InternalGas;
+use move_vm_runtime::native_functions::{NativeContext, NativeFunction};
+use move_vm_types::{
+    loaded_data::runtime_types::Type, natives::function::NativeResult, pop_arg, values::Value,
+};
+use smallvec::smallvec;
+use std::{collections::VecDeque, sync::Arc};
+
+use crate::natives::helpers::make_module_natives;
+
+#[derive(Debug, Clone)]
+pub struct DeriveIDGasParameters {
+    pub base: InternalGas,
+}
+
+impl DeriveIDGasParameters {
+    pub fn zeros() -> Self {
+        Self {
+            base: InternalGas::zero(),
+        }
+    }
+}
+
+//TODO merge this native function with table::new_table_handle
+pub fn native_derive_id(
+    gas_params: &DeriveIDGasParameters,
+    _context: &mut NativeContext,
+    ty_args: Vec<Type>,
+    mut args: VecDeque<Value>,
+) -> PartialVMResult<NativeResult> {
+    debug_assert!(ty_args.is_empty());
+    debug_assert!(args.len() == 2);
+
+    let ids_created = pop_arg!(args, u64);
+    let tx_hash = pop_arg!(args, Vec<u8>);
+
+    let object_id = ObjectID::derive_id(tx_hash, ids_created);
+    let cost = gas_params.base;
+    Ok(NativeResult::ok(
+        cost,
+        smallvec![Value::address(object_id.into())],
+    ))
+}
+
+pub fn make_native_derive_id(gas_params: DeriveIDGasParameters) -> NativeFunction {
+    Arc::new(
+        move |context, ty_args, args| -> PartialVMResult<NativeResult> {
+            native_derive_id(&gas_params, context, ty_args, args)
+        },
+    )
+}
+
+/***************************************************************************************************
+ * module
+ **************************************************************************************************/
+
+#[derive(Debug, Clone)]
+pub struct GasParameters {
+    pub derive_id: DeriveIDGasParameters,
+}
+
+impl GasParameters {
+    pub fn zeros() -> Self {
+        Self {
+            derive_id: DeriveIDGasParameters::zeros(),
+        }
+    }
+}
+
+pub fn make_all(gas_params: GasParameters) -> impl Iterator<Item = (String, NativeFunction)> {
+    let natives = [("derive_id", make_native_derive_id(gas_params.derive_id))];
+
+    make_module_natives(natives)
+}

--- a/crates/framework/tests/cases/object/basic.exp
+++ b/crates/framework/tests/cases/object/basic.exp
@@ -1,0 +1,1 @@
+processed 4 tasks

--- a/crates/framework/tests/cases/object/basic.exp
+++ b/crates/framework/tests/cases/object/basic.exp
@@ -1,1 +1,37 @@
-processed 4 tasks
+processed 10 tasks
+
+task 3 'view_object'. lines 38-40:
+store key 0x42::m::S {
+    id: store 0x1::object::UID {
+        id: copy drop store 0x1::object::ID {
+            bytes: ae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647
+        }
+    }
+}
+
+task 5 'view_object'. lines 44-47:
+store key 0x42::m::Cup<0x42::m::S> {
+    id: store 0x1::object::UID {
+        id: copy drop store 0x1::object::ID {
+            bytes: bbaf311ae6768a532b1f9dee65b1758a7bb1114fd57df8fa94cb2d1cb5f6896
+        }
+    }
+}
+
+task 7 'view'. lines 51-53:
+store key 0x42::m::S {
+    id: store 0x1::object::UID {
+        id: copy drop store 0x1::object::ID {
+            bytes: ae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647
+        }
+    }
+}
+
+task 9 'view'. lines 57-57:
+store key 0x42::m::Cup<0x42::m::S> {
+    id: store 0x1::object::UID {
+        id: copy drop store 0x1::object::ID {
+            bytes: bbaf311ae6768a532b1f9dee65b1758a7bb1114fd57df8fa94cb2d1cb5f6896
+        }
+    }
+}

--- a/crates/framework/tests/cases/object/basic.move
+++ b/crates/framework/tests/cases/object/basic.move
@@ -1,0 +1,30 @@
+//# init --addresses test=0x42 A=0x43
+
+//# publish
+
+module test::m {
+    use mos_std::tx_context::{Self, TxContext};
+    use mos_std::object::{Self, UID};
+
+    struct S has store, key { id: UID }
+    struct Cup<phantom T: store> has store, key { id: UID }
+
+    public entry fun mint_s(ctx: &mut TxContext) {
+        let id = object::new(ctx);
+        object::transfer(S { id }, tx_context::sender(ctx))
+    }
+
+    public entry fun mint_cup<T: store>(ctx: &mut TxContext) {
+        let id = object::new(ctx);
+        object::transfer(Cup<T> { id }, tx_context::sender(ctx))
+    }
+}
+
+// Mint S to A. Transfer S from A to B
+
+//# run test::m::mint_s --signers A
+
+// Mint Cup<S> to A. Transfer Cup<S> from A to B
+
+//# run test::m::mint_cup --type-args test::m::S --signers A
+

--- a/crates/framework/tests/cases/object/basic.move
+++ b/crates/framework/tests/cases/object/basic.move
@@ -5,26 +5,53 @@
 module test::m {
     use mos_std::tx_context::{Self, TxContext};
     use mos_std::object::{Self, UID};
+    use std::debug;
 
     struct S has store, key { id: UID }
     struct Cup<phantom T: store> has store, key { id: UID }
 
     public entry fun mint_s(ctx: &mut TxContext) {
         let id = object::new(ctx);
+        debug::print(&id);
         object::transfer(S { id }, tx_context::sender(ctx))
+    }
+
+    public entry fun move_s_to_global(sender: signer, s: S) {
+        move_to(&sender, s);
     }
 
     public entry fun mint_cup<T: store>(ctx: &mut TxContext) {
         let id = object::new(ctx);
+        debug::print(&id);
         object::transfer(Cup<T> { id }, tx_context::sender(ctx))
+    }
+
+    public entry fun move_cup_to_global<T:store>(sender: signer, cup: Cup<T>) {
+        move_to(&sender, cup);
     }
 }
 
-// Mint S to A. Transfer S from A to B
+// Mint S to A.
 
 //# run test::m::mint_s --signers A
 
-// Mint Cup<S> to A. Transfer Cup<S> from A to B
+//# view_object --object-id 0xae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647
+
+// Mint Cup<S> to A.
 
 //# run test::m::mint_cup --type-args test::m::S --signers A
 
+//# view_object --object-id 0xbbaf311ae6768a532b1f9dee65b1758a7bb1114fd57df8fa94cb2d1cb5f6896
+
+// Move S to global.
+//Currently, we use @address to pass object argument to the transaction, define a new way to pass object argument to the transaction.
+
+//# run test::m::move_s_to_global --signers A --args @0xae43e34e51db9c833ab50dd9aa8b27106519e5bbfd533737306e7b69ef253647
+
+//# view --address A --resource test::m::S
+
+// Move Cup<S> to global.
+
+//# run test::m::move_cup_to_global --signers A  --type-args test::m::S --args @0xbbaf311ae6768a532b1f9dee65b1758a7bb1114fd57df8fa94cb2d1cb5f6896
+
+//# view --address A --resource test::m::Cup<test::m::S>

--- a/crates/integration-test-runner/Cargo.toml
+++ b/crates/integration-test-runner/Cargo.toml
@@ -25,11 +25,13 @@ move-unit-test = { workspace = true, optional = true }
 move-vm-runtime = { workspace = true }
 move-vm-test-utils = { workspace = true }
 move-vm-types = { workspace = true }
+move-resource-viewer = { workspace = true }
 move-transactional-test-runner = { workspace = true }
 
 statedb = { workspace = true }
 framework = { workspace = true }
 moveos = { workspace = true }
+mos-types = { workspace = true }
 
 [dev-dependencies]
 datatest-stable = { workspace = true }

--- a/crates/mos-types/Cargo.toml
+++ b/crates/mos-types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "statedb"
+name = "mos-types"
 version = "0.1.0"
 edition = "2021"
 
@@ -8,12 +8,10 @@ edition = "2021"
 [dependencies]
 anyhow = { workspace = true }
 bcs = { workspace = true }
+thiserror = { workspace = true }
 smt = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 
 move-core-types = { workspace = true }
 move-table-extension = { workspace = true }
-
-mos-types = { workspace = true }
-framework = { workspace = true }

--- a/crates/mos-types/src/lib.rs
+++ b/crates/mos-types/src/lib.rs
@@ -1,9 +1,5 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-pub mod bcd;
 pub mod object;
-pub mod object_extension;
-pub mod rlp;
 pub mod tx_context;
-pub mod type_info;

--- a/crates/mos-types/src/object.rs
+++ b/crates/mos-types/src/object.rs
@@ -198,12 +198,19 @@ impl ObjectData {
 #[derive(Eq, PartialEq, Debug, Clone, Deserialize, Serialize, Hash)]
 pub struct MoveObject {
     pub type_: StructTag,
-    version: SequenceNumber,
+    pub version: SequenceNumber,
     #[serde(with = "serde_bytes")]
-    contents: Vec<u8>,
+    pub contents: Vec<u8>,
 }
 
 impl MoveObject {
+    pub fn new(type_: StructTag, version: SequenceNumber, contents: Vec<u8>) -> Self {
+        Self {
+            type_,
+            version,
+            contents,
+        }
+    }
     pub fn decode<T: MoveResource>(&self) -> Result<T, anyhow::Error> {
         if T::struct_tag() != self.type_ {
             anyhow::bail!(

--- a/crates/mos-types/src/tx_context.rs
+++ b/crates/mos-types/src/tx_context.rs
@@ -1,0 +1,65 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+//Source origin from https://github.com/MystenLabs/sui/blob/598f106ef5fbdfbe1b644236f0caf46c94f4d1b7/crates/sui-types/src/base_types.rs
+
+use move_core_types::{
+    account_address::AccountAddress, ident_str, identifier::IdentStr, move_resource::MoveStructType,
+};
+use serde::{Deserialize, Serialize};
+use smt::HashValue;
+
+use crate::object::ObjectID;
+
+pub const TX_CONTEXT_MODULE_NAME: &IdentStr = ident_str!("tx_context");
+pub const TX_CONTEXT_STRUCT_NAME: &IdentStr = ident_str!("TxContext");
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
+pub struct TxContext {
+    /// Signer/sender of the transaction
+    sender: AccountAddress,
+    /// Digest of the current transaction
+    tx_hash: HashValue,
+    /// Number of `ObjectID`'s generated during execution of the current transaction
+    ids_created: u64,
+}
+
+impl TxContext {
+    pub fn new(sender: AccountAddress, tx_hash: HashValue) -> Self {
+        Self {
+            sender,
+            tx_hash,
+            ids_created: 0,
+        }
+    }
+
+    /// Derive a globally unique object ID by hashing self.digest | self.ids_created
+    pub fn fresh_id(&mut self) -> ObjectID {
+        let id = ObjectID::derive_id(self.tx_hash.to_vec(), self.ids_created);
+        self.ids_created += 1;
+        id
+    }
+
+    /// Return the transaction Hash, to include in new objects
+    pub fn tx_hash(&self) -> HashValue {
+        self.tx_hash
+    }
+
+    pub fn sender(&self) -> AccountAddress {
+        self.sender
+    }
+
+    pub fn to_vec(&self) -> Vec<u8> {
+        bcs::to_bytes(&self).unwrap()
+    }
+
+    // for testing
+    pub fn random_for_testing_only() -> Self {
+        Self::new(AccountAddress::random(), HashValue::random())
+    }
+}
+
+impl MoveStructType for TxContext {
+    const MODULE_NAME: &'static IdentStr = TX_CONTEXT_MODULE_NAME;
+    const STRUCT_NAME: &'static IdentStr = TX_CONTEXT_STRUCT_NAME;
+}

--- a/crates/moveos/Cargo.toml
+++ b/crates/moveos/Cargo.toml
@@ -22,5 +22,6 @@ move-vm-runtime = { workspace = true }
 move-vm-test-utils = { workspace = true }
 move-vm-types = { workspace = true }
 
+mos-types = { workspace = true }
 statedb = { workspace = true }
 framework = { workspace = true }

--- a/crates/moveos/src/lib.rs
+++ b/crates/moveos/src/lib.rs
@@ -7,7 +7,7 @@ pub mod moveos;
 #[cfg(test)]
 mod tests;
 pub mod types;
-mod vm;
+pub mod vm;
 
 pub struct ValidatorResult {}
 

--- a/crates/moveos/src/moveos.rs
+++ b/crates/moveos/src/moveos.rs
@@ -260,8 +260,8 @@ where
             }
             None => false,
         },
-        Type::Reference(r) => is_tx_context(session, &r),
-        Type::MutableReference(r) => is_tx_context(session, &r),
+        Type::Reference(r) => is_tx_context(session, r),
+        Type::MutableReference(r) => is_tx_context(session, r),
         _ => false,
     }
 }

--- a/crates/moveos/src/moveos.rs
+++ b/crates/moveos/src/moveos.rs
@@ -11,17 +11,17 @@ use crate::{
 };
 use anyhow::Result;
 use framework::addresses::MOS_FRAMEWORK_ADDRESS;
+use framework::natives::mos_stdlib::object_extension::NativeObjectContext;
 use mos_types::tx_context::TxContext;
-use move_binary_format::errors::{Location};
+use move_binary_format::errors::Location;
 use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
 };
 use move_table_extension::NativeTableContext;
-use framework::natives::mos_stdlib::object_extension::NativeObjectContext;
-use move_vm_runtime::session::{SerializedReturnValues};
-use move_vm_types::{gas::UnmeteredGasMeter};
+use move_vm_runtime::session::SerializedReturnValues;
+use move_vm_types::gas::UnmeteredGasMeter;
 use statedb::{HashValue, StateDB};
 use std::borrow::Borrow;
 
@@ -132,7 +132,7 @@ impl MoveOS {
             .into_change_set()
             .map_err(|e| e.finish(Location::Undefined))?;
         self.db.apply_object_change_set(object_change_set)?;
-        
+
         Ok(())
     }
 
@@ -177,7 +177,6 @@ impl MoveOS {
         Ok(result)
     }
 }
-
 
 impl TransactionValidator for MoveOS {
     fn validate_transaction<T: AbstractTransaction>(

--- a/crates/moveos/src/moveos.rs
+++ b/crates/moveos/src/moveos.rs
@@ -8,11 +8,13 @@ use crate::{
 };
 use anyhow::Result;
 use framework::addresses::MOS_FRAMEWORK_ADDRESS;
+use mos_types::tx_context::TxContext;
 use move_binary_format::errors::{Location, PartialVMError, VMResult};
 use move_core_types::{
     account_address::AccountAddress,
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
+    move_resource::MoveStructType,
     value::MoveValue,
     vm_status::StatusCode,
 };
@@ -54,32 +56,37 @@ impl MoveOS {
     where
         T: AbstractTransaction,
     {
-        let session_id = txn.txn_hash();
+        let tx_hash = txn.txn_hash();
         let senders = txn.senders();
         let move_txn = txn.into_move_transaction();
-        let session = self.vm.new_session(&self.db, session_id);
-        self.execute_transaction(session, senders, move_txn)
+        let session = self.vm.new_session(&self.db, tx_hash);
+        self.execute_transaction(session, senders, tx_hash, move_txn)
     }
 
     fn execute_transaction<S>(
         &self,
         mut session: Session<S>,
         mut senders: Vec<AccountAddress>,
+        tx_hash: HashValue,
         txn: MoveTransaction,
     ) -> Result<()>
     where
         S: MoveResolverExt,
     {
         let mut gas_meter = UnmeteredGasMeter;
+        //TODO only allow one sender?
+        let sender = senders.pop().unwrap();
+        let tx_context = TxContext::new(sender, tx_hash);
         match txn {
             MoveTransaction::Script(script) => {
                 let loaded_function =
                     session.load_script(script.code.as_slice(), script.ty_args.clone())?;
                 //TODO find a nicer way to fill the signer arguments
                 let args = check_and_rearrange_args_by_signer_position(
+                    &session,
                     loaded_function,
                     script.args,
-                    senders.pop().unwrap(),
+                    tx_context,
                 )?;
                 let result =
                     session.execute_script(script.code, script.ty_args, args, &mut gas_meter)?;
@@ -96,9 +103,10 @@ impl MoveOS {
                 )?;
                 //TODO find a nicer way to fill the signer arguments
                 let args = check_and_rearrange_args_by_signer_position(
+                    &session,
                     loaded_function,
                     function.args,
-                    senders.pop().unwrap(),
+                    tx_context,
                 )?;
                 let result = session.execute_entry_function(
                     &function.module,
@@ -114,7 +122,6 @@ impl MoveOS {
             }
             MoveTransaction::ModuleBundle(modules) => {
                 //TODO check the modules package address with the sender
-                let sender = senders.pop().unwrap();
                 session.publish_module_bundle(modules, sender, &mut gas_meter)?;
             }
         }
@@ -174,11 +181,16 @@ impl MoveOS {
     }
 }
 
-fn check_and_rearrange_args_by_signer_position(
+//TODO refactor this, provide a TransactionParameterResolver trait, and let extension to provide.
+fn check_and_rearrange_args_by_signer_position<S>(
+    session: &Session<S>,
     func: LoadedFunctionInstantiation,
-    args: Vec<Vec<u8>>,
-    sender: AccountAddress,
-) -> VMResult<Vec<Vec<u8>>> {
+    mut args: Vec<Vec<u8>>,
+    tx_context: TxContext,
+) -> VMResult<Vec<Vec<u8>>>
+where
+    S: MoveResolverExt,
+{
     let has_signer = func
         .parameters
         .iter()
@@ -200,14 +212,57 @@ fn check_and_rearrange_args_by_signer_position(
         .unwrap_or(Ok(false))?;
 
     if has_signer {
-        let signer = MoveValue::Signer(sender);
-        let mut final_args = vec![signer
-            .simple_serialize()
-            .expect("serialize signer should success")];
-        final_args.extend(args);
-        Ok(final_args)
-    } else {
-        Ok(args)
+        let signer = MoveValue::Signer(tx_context.sender());
+        args.push(
+            signer
+                .simple_serialize()
+                .expect("serialize signer should success"),
+        );
+    }
+
+    let has_tx_context = func
+        .parameters
+        .iter()
+        .position(|i| is_tx_context(session, i))
+        .map(|pos| {
+            if pos != 0 {
+                Err(
+                    PartialVMError::new(StatusCode::NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH)
+                        .with_message(format!(
+                            "Expected TxContext arg is this first arg, but got it at {}",
+                            pos + 1
+                        ))
+                        .finish(Location::Undefined),
+                )
+            } else {
+                Ok(true)
+            }
+        })
+        .unwrap_or(Ok(false))?;
+
+    if has_tx_context {
+        args.push(tx_context.to_vec());
+    }
+
+    Ok(args)
+}
+
+fn is_tx_context<T>(session: &Session<T>, t: &Type) -> bool
+where
+    T: MoveResolverExt,
+{
+    match t {
+        Type::Struct(s) => match session.get_struct_type(*s) {
+            Some(t) => {
+                *t.module.address() == *framework::addresses::MOS_STD_ADDRESS
+                    && t.module.name() == TxContext::module_identifier().as_ident_str()
+                    && t.name == TxContext::struct_identifier()
+            }
+            None => false,
+        },
+        Type::Reference(r) => is_tx_context(session, &r),
+        Type::MutableReference(r) => is_tx_context(session, &r),
+        _ => false,
     }
 }
 

--- a/crates/moveos/src/vm/mod.rs
+++ b/crates/moveos/src/vm/mod.rs
@@ -1,11 +1,12 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
+use framework::natives::mos_stdlib::object_extension::ObjectResolver;
 use move_core_types::resolver::MoveResolver;
 use move_table_extension::TableResolver;
 
 pub mod move_vm_ext;
 
-pub trait MoveResolverExt: MoveResolver + TableResolver {}
+pub trait MoveResolverExt: MoveResolver + TableResolver + ObjectResolver {}
 
-impl<T> MoveResolverExt for T where T: MoveResolver + TableResolver {}
+impl<T> MoveResolverExt for T where T: MoveResolver + TableResolver + ObjectResolver {}

--- a/crates/moveos/src/vm/mod.rs
+++ b/crates/moveos/src/vm/mod.rs
@@ -6,6 +6,7 @@ use move_core_types::resolver::MoveResolver;
 use move_table_extension::TableResolver;
 
 pub mod move_vm_ext;
+pub mod tx_argument_resolver;
 
 pub trait MoveResolverExt: MoveResolver + TableResolver + ObjectResolver {}
 

--- a/crates/moveos/src/vm/move_vm_ext.rs
+++ b/crates/moveos/src/vm/move_vm_ext.rs
@@ -1,13 +1,31 @@
 // Copyright (c) RoochNetwork
 // SPDX-License-Identifier: Apache-2.0
 
-use super::MoveResolverExt;
+use std::{borrow::Borrow, sync::Arc};
+
+use super::{tx_argument_resolver::TxArgumentResolver, MoveResolverExt};
 use framework::natives::{self, mos_stdlib::object_extension::NativeObjectContext, GasParameters};
-use move_binary_format::errors::VMResult;
+use mos_types::tx_context::TxContext;
+use move_binary_format::{compatibility::Compatibility, errors::{VMResult, PartialVMError}, file_format::AbilitySet};
 use move_bytecode_verifier::VerifierConfig;
+use move_core_types::{
+    account_address::AccountAddress,
+    effects::{ChangeSet, Event},
+    identifier::IdentStr,
+    language_storage::{ModuleId, TypeTag},
+    value::MoveTypeLayout,
+};
 use move_table_extension::NativeTableContext;
 use move_vm_runtime::{
-    config::VMConfig, move_vm::MoveVM, native_extensions::NativeContextExtensions, session::Session,
+    config::VMConfig,
+    move_vm::MoveVM,
+    native_extensions::NativeContextExtensions,
+    session::{LoadedFunctionInstantiation, SerializedReturnValues, Session},
+};
+use move_vm_types::{
+    data_store::DataStore,
+    gas::GasMeter,
+    loaded_data::runtime_types::{CachedStructIndex, StructType, Type},
 };
 use statedb::HashValue;
 
@@ -34,7 +52,7 @@ impl MoveVmExt {
         &self,
         remote: &'r S,
         session_id: HashValue,
-    ) -> Session<'r, '_, S> {
+    ) -> SessionExt<'r, '_, S> {
         let mut extensions = NativeContextExtensions::default();
         let txn_hash: [u8; 32] = session_id.into();
 
@@ -45,6 +63,182 @@ impl MoveVmExt {
         // cache needs to be flushed to work around those bugs.
         self.inner.flush_loader_cache_if_invalidated();
 
-        self.inner.new_session_with_extensions(remote, extensions)
+        let session = self.inner.new_session_with_extensions(remote, extensions);
+        SessionExt::new(session)
+    }
+}
+
+pub struct SessionExt<'r, 'l, S> {
+    session: Session<'r, 'l, S>,
+}
+
+impl<'r, 'l, S> SessionExt<'r, 'l, S>
+where
+    S: MoveResolverExt,
+{
+    pub fn new(session: Session<'r, 'l, S>) -> Self {
+        Self { session }
+    }
+
+    pub fn resolve_args(
+        &self,
+        tx_context: &TxContext,
+        func: LoadedFunctionInstantiation,
+        args: Vec<Vec<u8>>,
+    ) -> Result<Vec<Vec<u8>>, PartialVMError> {
+        let args = tx_context.resolve_argument(self, &func, args)?;
+        let object_context = self
+            .session
+            .get_native_extensions()
+            .get::<NativeObjectContext>();
+        object_context.resolve_argument(self,&func, args)
+    }
+
+    /************** Proxy function */
+
+    pub fn execute_entry_function(
+        &mut self,
+        module: &ModuleId,
+        function_name: &IdentStr,
+        ty_args: Vec<TypeTag>,
+        args: Vec<impl Borrow<[u8]>>,
+        gas_meter: &mut impl GasMeter,
+    ) -> VMResult<SerializedReturnValues> {
+        self.session
+            .execute_entry_function(module, function_name, ty_args, args, gas_meter)
+    }
+
+    pub fn execute_function_bypass_visibility(
+        &mut self,
+        module: &ModuleId,
+        function_name: &IdentStr,
+        ty_args: Vec<TypeTag>,
+        args: Vec<impl Borrow<[u8]>>,
+        gas_meter: &mut impl GasMeter,
+    ) -> VMResult<SerializedReturnValues> {
+        self.session.execute_function_bypass_visibility(
+            module,
+            function_name,
+            ty_args,
+            args,
+            gas_meter,
+        )
+    }
+
+    pub fn execute_script(
+        &mut self,
+        script: impl Borrow<[u8]>,
+        ty_args: Vec<TypeTag>,
+        args: Vec<impl Borrow<[u8]>>,
+        gas_meter: &mut impl GasMeter,
+    ) -> VMResult<SerializedReturnValues> {
+        self.session
+            .execute_script(script, ty_args, args, gas_meter)
+    }
+
+    pub fn publish_module(
+        &mut self,
+        module: Vec<u8>,
+        sender: AccountAddress,
+        gas_meter: &mut impl GasMeter,
+    ) -> VMResult<()> {
+        self.session.publish_module(module, sender, gas_meter)
+    }
+
+    pub fn publish_module_bundle(
+        &mut self,
+        modules: Vec<Vec<u8>>,
+        sender: AccountAddress,
+        gas_meter: &mut impl GasMeter,
+    ) -> VMResult<()> {
+        self.session
+            .publish_module_bundle(modules, sender, gas_meter)
+    }
+
+    pub fn publish_module_bundle_with_compat_config(
+        &mut self,
+        modules: Vec<Vec<u8>>,
+        sender: AccountAddress,
+        gas_meter: &mut impl GasMeter,
+        compat_config: Compatibility,
+    ) -> VMResult<()> {
+        self.session.publish_module_bundle_with_compat_config(
+            modules,
+            sender,
+            gas_meter,
+            compat_config,
+        )
+    }
+
+    pub fn num_mutated_accounts(&self, sender: &AccountAddress) -> u64 {
+        self.session.num_mutated_accounts(sender)
+    }
+
+    pub fn finish(self) -> VMResult<(ChangeSet, Vec<Event>)> {
+        self.session.finish()
+    }
+
+    pub fn finish_with_extensions(
+        self,
+    ) -> VMResult<(ChangeSet, Vec<Event>, NativeContextExtensions<'r>)> {
+        self.session.finish_with_extensions()
+    }
+
+    /// Load a script and all of its types into cache
+    pub fn load_script(
+        &self,
+        script: impl Borrow<[u8]>,
+        ty_args: Vec<TypeTag>,
+    ) -> VMResult<LoadedFunctionInstantiation> {
+        self.session.load_script(script, ty_args)
+    }
+
+    /// Load a module, a function, and all of its types into cache
+    pub fn load_function(
+        &self,
+        module_id: &ModuleId,
+        function_name: &IdentStr,
+        type_arguments: &[TypeTag],
+    ) -> VMResult<LoadedFunctionInstantiation> {
+        self.session
+            .load_function(module_id, function_name, type_arguments)
+    }
+
+    pub fn load_type(&self, type_tag: &TypeTag) -> VMResult<Type> {
+        self.session.load_type(type_tag)
+    }
+
+    pub fn get_type_layout(&self, type_tag: &TypeTag) -> VMResult<MoveTypeLayout> {
+        self.session.get_type_layout(type_tag)
+    }
+
+    pub fn get_fully_annotated_type_layout(&self, type_tag: &TypeTag) -> VMResult<MoveTypeLayout> {
+        self.session.get_fully_annotated_type_layout(type_tag)
+    }
+
+    pub fn get_type_tag(&self, ty: &Type) -> VMResult<TypeTag> {
+        self.session.get_type_tag(ty)
+    }
+
+    pub fn get_struct_type(&self, index: CachedStructIndex) -> Option<Arc<StructType>> {
+        self.session.get_struct_type(index)
+    }
+
+    pub fn get_type_abilities(&self, ty: &Type) -> VMResult<AbilitySet> {
+        self.session.get_type_abilities(ty)
+    }
+
+    pub fn get_data_store(&mut self) -> &mut dyn DataStore {
+        self.session.get_data_store()
+    }
+
+    pub fn get_native_extensions(&self) -> &NativeContextExtensions<'r> {
+        self.session.get_native_extensions()
+    }
+}
+
+impl AsRef<MoveVM> for MoveVmExt {
+    fn as_ref(&self) -> &MoveVM {
+        &self.inner
     }
 }

--- a/crates/moveos/src/vm/move_vm_ext.rs
+++ b/crates/moveos/src/vm/move_vm_ext.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::MoveResolverExt;
-use framework::natives::{self, GasParameters};
+use framework::natives::{self, mos_stdlib::object_extension::NativeObjectContext, GasParameters};
 use move_binary_format::errors::VMResult;
 use move_bytecode_verifier::VerifierConfig;
 use move_table_extension::NativeTableContext;
@@ -39,6 +39,7 @@ impl MoveVmExt {
         let txn_hash: [u8; 32] = session_id.into();
 
         extensions.add(NativeTableContext::new(txn_hash, remote));
+        extensions.add(NativeObjectContext::new(remote));
 
         // The VM code loader has bugs around module upgrade. After a module upgrade, the internal
         // cache needs to be flushed to work around those bugs.

--- a/crates/moveos/src/vm/move_vm_ext.rs
+++ b/crates/moveos/src/vm/move_vm_ext.rs
@@ -6,7 +6,11 @@ use std::{borrow::Borrow, sync::Arc};
 use super::{tx_argument_resolver::TxArgumentResolver, MoveResolverExt};
 use framework::natives::{self, mos_stdlib::object_extension::NativeObjectContext, GasParameters};
 use mos_types::tx_context::TxContext;
-use move_binary_format::{compatibility::Compatibility, errors::{VMResult, PartialVMError}, file_format::AbilitySet};
+use move_binary_format::{
+    compatibility::Compatibility,
+    errors::{PartialVMError, VMResult},
+    file_format::AbilitySet,
+};
 use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{
     account_address::AccountAddress,
@@ -91,7 +95,7 @@ where
             .session
             .get_native_extensions()
             .get::<NativeObjectContext>();
-        object_context.resolve_argument(self,&func, args)
+        object_context.resolve_argument(self, &func, args)
     }
 
     /************** Proxy function */

--- a/crates/moveos/src/vm/tx_argument_resolver.rs
+++ b/crates/moveos/src/vm/tx_argument_resolver.rs
@@ -1,0 +1,195 @@
+// Copyright (c) RoochNetwork
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{Result};
+use framework::natives::mos_stdlib::object_extension::NativeObjectContext;
+use mos_types::{
+    object::{Object, ObjectData, ObjectID},
+    tx_context::TxContext,
+};
+use move_binary_format::errors::{PartialVMError};
+use move_core_types::{move_resource::MoveStructType, value::MoveValue, vm_status::StatusCode};
+use move_vm_runtime::session::LoadedFunctionInstantiation;
+use move_vm_types::loaded_data::runtime_types::{StructType, Type};
+use std::sync::Arc;
+
+use super::{move_vm_ext::SessionExt, MoveResolverExt};
+
+/// Transaction Argument Resolver will implemented by the Move Extension
+/// to auto fill transaction argument or do type conversion.
+// TODO: Try to push to Move upstream if possible.
+pub trait TxArgumentResolver {
+    fn resolve_argument<S>(
+        &self,
+        session: &SessionExt<S>,
+        func: &LoadedFunctionInstantiation,
+        args: Vec<Vec<u8>>,
+    ) -> Result<Vec<Vec<u8>>, PartialVMError>
+    where
+        S: MoveResolverExt;
+}
+
+impl TxArgumentResolver for TxContext {
+    fn resolve_argument<S>(
+        &self,
+        session: &SessionExt<S>,
+        func: &LoadedFunctionInstantiation,
+        mut args: Vec<Vec<u8>>,
+    ) -> Result<Vec<Vec<u8>>, PartialVMError>
+    where
+        S: MoveResolverExt,
+    {
+        let has_signer = func
+            .parameters
+            .iter()
+            .position(|i| matches!(i, Type::Signer))
+            .map(|pos| {
+                if pos != 0 {
+                    Err(
+                        PartialVMError::new(StatusCode::NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH)
+                            .with_message(format!(
+                                "Expected signer arg is this first arg, but got it at {}",
+                                pos + 1
+                            )),
+                    )
+                } else {
+                    Ok(true)
+                }
+            })
+            .unwrap_or(Ok(false))?;
+
+        if has_signer {
+            let signer = MoveValue::Signer(self.sender());
+            args.push(
+                signer
+                    .simple_serialize()
+                    .expect("serialize signer should success"),
+            );
+        }
+
+        let has_tx_context = func
+            .parameters
+            .iter()
+            .position(|i| {
+                is_object(session, i)
+                    .map(|t| is_tx_context(&t))
+                    .unwrap_or(false)
+            })
+            .map(|pos| {
+                if pos != 0 {
+                    Err(
+                        PartialVMError::new(StatusCode::NUMBER_OF_SIGNER_ARGUMENTS_MISMATCH)
+                            .with_message(format!(
+                                "Expected TxContext arg is this first arg, but got it at {}",
+                                pos + 1
+                            )))
+                            
+                } else {
+                    Ok(true)
+                }
+            })
+            .unwrap_or(Ok(false))?;
+
+        if has_tx_context {
+            args.push(self.to_vec());
+        }
+
+        Ok(args)
+    }
+}
+
+// TODO move to move_table_extension
+impl TxArgumentResolver for move_table_extension::NativeTableContext<'_> {
+    fn resolve_argument<S>(
+        &self,
+        _session: &SessionExt<S>,
+        _func: &LoadedFunctionInstantiation,
+        args: Vec<Vec<u8>>,
+    ) -> Result<Vec<Vec<u8>>, PartialVMError>
+    where
+        S: MoveResolverExt,
+    {
+        //TableContext do nothing to the arguments now.
+        Ok(args)
+    }
+}
+
+//TODO move to NativeObjectContext
+impl TxArgumentResolver for NativeObjectContext<'_> {
+    fn resolve_argument<S>(
+        &self,
+        session: &SessionExt<S>,
+        func: &LoadedFunctionInstantiation,
+        args: Vec<Vec<u8>>,
+    ) -> Result<Vec<Vec<u8>>, PartialVMError>
+    where
+        S: MoveResolverExt,
+    {
+        if args.len() != func.parameters.len() {
+            return Err(PartialVMError::new(StatusCode::NUMBER_OF_ARGUMENTS_MISMATCH))
+        }
+            
+        
+        let mut resolved_args = vec![];
+        for (i, (t, arg)) in func.parameters.iter().zip(args.iter()).enumerate() {
+            let is_object = is_object(session, t);
+            let arg = match is_object {
+                Some(t) => {
+                    //skip tx context
+                    if is_tx_context(&t) {
+                        arg.clone()
+                    } else {
+                        let object_id = ObjectID::from_bytes(arg).map_err(|_e| {
+                            PartialVMError::new(StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH)
+                        })?;
+                        let object: Object = self.get_object(object_id)?.ok_or_else(|| {
+                            
+                                PartialVMError::new(StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH)
+                                    .with_message(format!("Can not find object: {:?}", object_id))
+                            
+                        })?;
+                        match object.data {
+                            ObjectData::MoveObject(m) => m.contents,
+                            ObjectData::TableObject(_) => {
+                                return Err(PartialVMError::new(
+                                    StatusCode::NUMBER_OF_TYPE_ARGUMENTS_MISMATCH,
+                                )
+                                .with_message(format!(
+                            "Table object is not supported as argument currently, argument pos: {}",
+                            i + 1
+                        )))
+                            }
+                        }
+                    }
+                }
+                None => arg.clone(),
+            };
+            resolved_args.push(arg);
+        }
+
+        Ok(args)
+    }
+}
+
+fn is_object<T>(session: &SessionExt<T>, t: &Type) -> Option<Arc<StructType>>
+where
+    T: MoveResolverExt,
+{
+    match t {
+        Type::Struct(s) => match session.get_struct_type(*s) {
+            Some(t) => Some(t),
+            None => {
+                panic!("Can not find bype for struct: {:?}", s)
+            }
+        },
+        Type::Reference(r) => is_object(session, r),
+        Type::MutableReference(r) => is_object(session, r),
+        _ => None,
+    }
+}
+
+fn is_tx_context(t: &StructType) -> bool {
+    *t.module.address() == *framework::addresses::MOS_STD_ADDRESS
+        && t.module.name() == TxContext::module_identifier().as_ident_str()
+        && t.name == TxContext::struct_identifier()
+}

--- a/crates/moveos/src/vm/tx_argument_resolver.rs
+++ b/crates/moveos/src/vm/tx_argument_resolver.rs
@@ -42,7 +42,7 @@ impl TxArgumentResolver for TxContext {
         let has_signer = func
             .parameters
             .iter()
-            .position(|t| is_signer(t))
+            .position(is_signer)
             .map(|pos| {
                 if pos != 0 {
                     Err(

--- a/crates/statedb/src/lib.rs
+++ b/crates/statedb/src/lib.rs
@@ -2,6 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use framework::natives::mos_stdlib::object_extension::ObjectResolver;
+use mos_types::object::{NamedTableID, Object, ObjectID, TableObject};
 use move_core_types::{
     account_address::AccountAddress,
     effects::{ChangeSet, Op},
@@ -10,13 +12,11 @@ use move_core_types::{
     resolver::{ModuleResolver, ResourceResolver},
 };
 use move_table_extension::{TableChangeSet, TableResolver};
-use object::{NamedTableID, Object, ObjectID, TableObject};
 use smt::{InMemoryNodeStore, NodeStore, SMTree, UpdateSet};
 use std::collections::BTreeMap;
 
 pub use smt::HashValue;
 
-pub mod object;
 #[cfg(test)]
 mod tests;
 
@@ -233,5 +233,11 @@ impl TableResolver for StateDB {
         key: &[u8],
     ) -> std::result::Result<Option<Vec<u8>>, anyhow::Error> {
         self.get_with_key((*handle).into(), key.to_vec())
+    }
+}
+
+impl ObjectResolver for StateDB {
+    fn resolve_object(&self, id: ObjectID) -> Result<Option<Object>> {
+        self.get(id)
     }
 }

--- a/crates/statedb/src/lib.rs
+++ b/crates/statedb/src/lib.rs
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use framework::natives::mos_stdlib::object_extension::{ObjectResolver, ObjectChangeSet};
-use mos_types::object::{NamedTableID, Object, ObjectID, TableObject, MoveObject};
+use framework::natives::mos_stdlib::object_extension::{ObjectChangeSet, ObjectResolver};
+use mos_types::object::{MoveObject, NamedTableID, Object, ObjectID, TableObject};
 use move_core_types::{
     account_address::AccountAddress,
     effects::{ChangeSet, Op},
     identifier::Identifier,
     language_storage::{ModuleId, StructTag},
-    resolver::{ModuleResolver, ResourceResolver}, value::MoveTypeLayout,
+    resolver::{ModuleResolver, ResourceResolver},
+    value::MoveTypeLayout,
 };
 use move_table_extension::{TableChangeSet, TableResolver};
 use smt::{InMemoryNodeStore, NodeStore, SMTree, UpdateSet};
@@ -199,9 +200,15 @@ impl StateDB {
         let mut changed_objects = UpdateSet::new();
         for (object_id, object_info) in change_set.new_objects {
             //TODO should serialize at the extension when make change set
-            let contents = object_info.value.simple_serialize(&MoveTypeLayout::Struct(object_info.layout)).unwrap();
+            let contents = object_info
+                .value
+                .simple_serialize(&MoveTypeLayout::Struct(object_info.layout))
+                .unwrap();
             //TODO set version
-            changed_objects.put(object_id, Object::new_move_object(MoveObject::new(object_info.tag, 1, contents)));
+            changed_objects.put(
+                object_id,
+                Object::new_move_object(MoveObject::new(object_info.tag, 1, contents)),
+            );
         }
         self.smt.puts(changed_objects)
     }


### PR DESCRIPTION
Add hybrid Object and global storage example.

https://github.com/rooch-network/moveos/blob/object_move/crates/framework/tests/cases/object/basic.move

```move
module test::m {
    use mos_std::tx_context::{Self, TxContext};
    use mos_std::object::{Self, UID};
    use std::debug;

    struct S has store, key { id: UID }
    struct Cup<phantom T: store> has store, key { id: UID }

    public entry fun mint_s(ctx: &mut TxContext) {
        let id = object::new(ctx);
        debug::print(&id);
        object::transfer(S { id }, tx_context::sender(ctx))
    }

    public entry fun move_s_to_global(sender: signer, s: S) {
        move_to(&sender, s);
    }

    public entry fun mint_cup<T: store>(ctx: &mut TxContext) {
        let id = object::new(ctx);
        debug::print(&id);
        object::transfer(Cup<T> { id }, tx_context::sender(ctx))
    }

    public entry fun move_cup_to_global<T:store>(sender: signer, cup: Cup<T>) {
        move_to(&sender, cup);
    }
}
```

## The Object in StateDB

<img width="1249" alt="moveos statedb" src="https://user-images.githubusercontent.com/77268/228173501-e837fa36-a80b-4031-95ed-811746906ffc.png">

1. Anything is an Object, including the Table.
2. A user has two tables, one for store Resources and another for store Modules.
3. Object in the global state tree, the key is ObjectID.
4. Every Table is an SMT tree. The Table Object stores the SMT's state root.
5. Normal resource struct can ref an object by the ObjectRef(TODO).

## TODO in the following PR

1. Object Reference
2. Process the Object argument, and distinguish between Object Reference(&Object) and Object Value. The object value argument will move the object from the global state tree.
3. Define Object ownership and lifetime.
4. The best practice when using Object and when using Global Storage