### PR TITLE
[DevOps] Switch ci yaml file from docs/contributions to main branch

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-    - uses: rooch-network/moveos/.github/actions/rust-setup@docs/contributions
+    - uses: rooch-network/moveos/.github/actions/rust-setup@main
     #  with:
     #    fetch-depth: 0
     - name: Check code format

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -37,7 +37,7 @@ function usage {
   echo "-p update ${HOME}/.profile"
   echo "-r install protoc and related tools"
   echo "-t install build tools"
-  echo "-o install operations tooling as well: helm, terraform, yamllint, vault, docker, kubectl, python3"
+  echo "-o install operations tooling as well: yamllint, docker,  python3"
   echo "-y installs or updates Move prover tools: z3, cvc5, dotnet, boogie"
   echo "-a install tools for build and test api"
   echo "-v verbose mode"
@@ -620,10 +620,6 @@ Operation tools (since -o was provided):
   * yamllint
   * python3
   * docker
-  * vault
-  * terraform
-  * kubectl
-  * helm
   * aws cli
   * allure
 EOF


### PR DESCRIPTION
The docs/contribtons branch have deleted after it merged to main branch, so the ci yaml file should reference to main branch.